### PR TITLE
feat(planning): módulo de planejamento de metas de poupança

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,10 @@ const HistoricoPage = lazy(() =>
   import('./pages/HistoricoPage').then((module) => ({ default: module.HistoricoPage }))
 );
 
+const PlanejamentoPage = lazy(() =>
+  import('./pages/PlanejamentoPage').then((module) => ({ default: module.PlanejamentoPage }))
+);
+
 interface AuthenticatedAppProps {
   session: AuthSessionDto;
   onLogout: () => Promise<void>;
@@ -114,6 +118,7 @@ function AuthenticatedApp({ session, onLogout, loggingOut }: AuthenticatedAppPro
               path="/metas"
               element={<MetasPage monthId={selectedMonthId} readOnly={selectedMonth?.status === 'CLOSED'} />}
             />
+            <Route path="/planejamento" element={<PlanejamentoPage />} />
             <Route path="/historico" element={<HistoricoPage months={months} />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -53,6 +53,14 @@ function IconGoals() {
   );
 }
 
+function IconPlanning() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+    </svg>
+  );
+}
+
 function IconHistory() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -233,6 +241,7 @@ export function Layout({
         <NavLink to="/orcamento"><IconBudget /><span>Orçamento</span></NavLink>
         <NavLink to="/lancamentos"><IconEntries /><span>Lançamentos</span></NavLink>
         <NavLink to="/metas"><IconGoals /><span>Metas</span></NavLink>
+        <NavLink to="/planejamento"><IconPlanning /><span>Planejamento</span></NavLink>
         <NavLink to="/historico"><IconHistory /><span>Histórico</span></NavLink>
       </nav>
 

--- a/frontend/src/pages/PlanejamentoPage.tsx
+++ b/frontend/src/pages/PlanejamentoPage.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { formatCurrency } from '../utils/format';
+import { PrivacyMask } from '../contexts/PrivacyContext';
+
+type Goal = {
+  id: number;
+  name: string;
+  totalAmount: number;
+  savedAmount: number;
+  months: number;
+};
+
+let nextId = 1;
+
+function calcMonthly(goal: Goal) {
+  const remaining = Math.max(0, goal.totalAmount - goal.savedAmount);
+  return goal.months > 0 ? remaining / goal.months : 0;
+}
+
+function MonthlyImpact({ monthly, salary }: { monthly: number; salary: number }) {
+  if (salary <= 0) return null;
+  const pct = (monthly / salary) * 100;
+  return (
+    <span className={pct > 30 ? 'negative' : ''}>
+      {' '}({pct.toFixed(1)}% do salário)
+    </span>
+  );
+}
+
+export function PlanejamentoPage() {
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [salary, setSalary] = useState('');
+  const [name, setName] = useState('');
+  const [totalAmount, setTotalAmount] = useState('');
+  const [savedAmount, setSavedAmount] = useState('');
+  const [months, setMonths] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  function addGoal() {
+    const total = Number(totalAmount.replace(',', '.'));
+    const saved = Number(savedAmount.replace(',', '.'));
+    const m = Number(months);
+
+    if (!name.trim()) { setError('Informe o nome do objetivo.'); return; }
+    if (!total || total <= 0) { setError('Informe um valor total válido.'); return; }
+    if (saved < 0 || saved > total) { setError('Valor já guardado inválido.'); return; }
+    if (!m || m <= 0 || !Number.isInteger(m)) { setError('Informe um prazo em meses válido.'); return; }
+
+    setError(null);
+    setGoals((prev) => [...prev, { id: nextId++, name: name.trim(), totalAmount: total, savedAmount: saved, months: m }]);
+    setName('');
+    setTotalAmount('');
+    setSavedAmount('');
+    setMonths('');
+  }
+
+  function removeGoal(id: number) {
+    setGoals((prev) => prev.filter((g) => g.id !== id));
+  }
+
+  const parsedSalary = Number(salary.replace(',', '.'));
+  const totalMonthly = goals.reduce((sum, g) => sum + calcMonthly(g), 0);
+
+  return (
+    <section className="panel">
+      <header className="panel-header">
+        <h2>Planejamento de objetivos</h2>
+      </header>
+
+      <div className="inline-form" style={{ marginBottom: '1.5rem' }}>
+        <label htmlFor="plan-salary">Salário (referência)</label>
+        <input
+          id="plan-salary"
+          type="number"
+          step="0.01"
+          placeholder="Ex: 5000"
+          value={salary}
+          onChange={(e) => setSalary(e.target.value)}
+          style={{ maxWidth: 160 }}
+        />
+      </div>
+
+      <h3>Novo objetivo</h3>
+      <div className="inline-form">
+        <input
+          placeholder="Nome do objetivo"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={{ minWidth: 180 }}
+        />
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Valor total (R$)"
+          value={totalAmount}
+          onChange={(e) => setTotalAmount(e.target.value)}
+        />
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Já guardado (R$)"
+          value={savedAmount}
+          onChange={(e) => setSavedAmount(e.target.value)}
+        />
+        <input
+          type="number"
+          step="1"
+          placeholder="Prazo (meses)"
+          value={months}
+          onChange={(e) => setMonths(e.target.value)}
+        />
+        <button type="button" onClick={addGoal}>
+          Adicionar
+        </button>
+      </div>
+      {error && <p className="inline-error" role="alert">{error}</p>}
+
+      {goals.length > 0 && (
+        <>
+          <table className="data-table" style={{ marginTop: '1.5rem' }}>
+            <thead>
+              <tr>
+                <th>Objetivo</th>
+                <th>Valor total</th>
+                <th>Já guardado</th>
+                <th>Falta</th>
+                <th>Prazo</th>
+                <th>Guardar/mês</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {goals.map((goal) => {
+                const monthly = calcMonthly(goal);
+                const remaining = Math.max(0, goal.totalAmount - goal.savedAmount);
+                return (
+                  <tr key={goal.id}>
+                    <td>{goal.name}</td>
+                    <td><PrivacyMask value={formatCurrency(goal.totalAmount)} /></td>
+                    <td><PrivacyMask value={formatCurrency(goal.savedAmount)} /></td>
+                    <td><PrivacyMask value={formatCurrency(remaining)} /></td>
+                    <td>{goal.months} {goal.months === 1 ? 'mês' : 'meses'}</td>
+                    <td>
+                      <PrivacyMask value={formatCurrency(monthly)} />
+                      <MonthlyImpact monthly={monthly} salary={parsedSalary} />
+                    </td>
+                    <td>
+                      <button type="button" className="button-secondary" onClick={() => removeGoal(goal.id)}>
+                        Remover
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div className="panel-header" style={{ marginTop: '1rem', borderTop: '1px solid var(--border)', paddingTop: '1rem' }}>
+            <p>
+              <strong>Total a guardar por mês: </strong>
+              <PrivacyMask value={formatCurrency(totalMonthly)} />
+              <MonthlyImpact monthly={totalMonthly} salary={parsedSalary} />
+            </p>
+          </div>
+        </>
+      )}
+
+      {goals.length === 0 && (
+        <p style={{ marginTop: '1.5rem', color: 'var(--text-secondary)' }}>
+          Nenhum objetivo adicionado ainda. Use o formulário acima para calcular quanto guardar por mês.
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Nova página `/planejamento` com calculadora de objetivos de poupança
- Permite adicionar múltiplos objetivos com nome, valor total, valor já guardado e prazo em meses
- Calcula quanto guardar por mês por objetivo e o impacto percentual no salário (destaque vermelho se > 30%)
- Total consolidado de todos os objetivos no rodapé

## Test plan
- [ ] Acessar `/planejamento` e adicionar um objetivo
- [ ] Verificar cálculo de valor mensal (falta / meses)
- [ ] Informar salário e verificar % de impacto
- [ ] Adicionar múltiplos objetivos e conferir o total consolidado
- [ ] Remover objetivo e verificar que o total atualiza

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)