### PR TITLE
refactor: introduce Application layer

### DIFF
--- a/backend/CostTracker.Api/Controllers/AuthController.cs
+++ b/backend/CostTracker.Api/Controllers/AuthController.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 using CostTracker.Api.Configuration;
-using CostTracker.Api.Contracts;
+using CostTracker.Application.Contracts;
 using CostTracker.Api.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;

--- a/backend/CostTracker.Api/Controllers/BudgetController.cs
+++ b/backend/CostTracker.Api/Controllers/BudgetController.cs
@@ -1,202 +1,36 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Api.Services;
-using CostTracker.Domain.Constants;
-using CostTracker.Domain.Entities;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/months/{monthId:guid}/budget")]
-public class BudgetController(
-    CostTrackerDbContext dbContext,
-    MonthProjectionService projectionService) : ControllerBase
+public class BudgetController(BudgetService budgetService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<BudgetResponseDto>> GetBudget(Guid monthId, CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        return Ok(projectionService.ToBudgetResponse(month));
-    }
+    public async Task<ActionResult<BudgetResponseDto>> GetBudget(Guid monthId, CancellationToken ct)
+        => Ok(await budgetService.GetBudgetAsync(monthId, ct));
 
     [HttpPost("categories")]
     public async Task<ActionResult<BudgetResponseDto>> CreateCategory(
         Guid monthId,
         [FromBody] CreateCategoryRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.GroupName))
-        {
-            return BadRequest("name and groupName are required.");
-        }
-
-        if (request.PlannedAmount < 0)
-        {
-            return BadRequest("plannedAmount must be greater than or equal to zero.");
-        }
-
-        var normalizedName = CategoryNames.Normalize(request.Name);
-        var normalizedGroupName = GroupNames.Normalize(request.GroupName);
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var alreadyExists = month.CategoryBudgets
-            .Any(x => string.Equals(x.Name, normalizedName, StringComparison.OrdinalIgnoreCase));
-
-        if (alreadyExists)
-        {
-            return Conflict("Category name already exists for this month.");
-        }
-
-        var displayOrder = request.DisplayOrder ?? month.CategoryBudgets.Select(x => x.DisplayOrder).DefaultIfEmpty(0).Max() + 1;
-
-        var category = new CategoryBudget
-        {
-            Id = Guid.NewGuid(),
-            MonthId = monthId,
-            Name = normalizedName,
-            GroupName = normalizedGroupName,
-            PlannedAmount = decimal.Round(request.PlannedAmount, 2),
-            DisplayOrder = displayOrder
-        };
-
-        await dbContext.CategoryBudgets.AddAsync(category, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToBudgetResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await budgetService.CreateCategoryAsync(monthId, request, ct));
 
     [HttpPut("categories/{categoryId:guid}")]
     public async Task<ActionResult<BudgetResponseDto>> UpdateCategory(
         Guid monthId,
         Guid categoryId,
         [FromBody] UpdateCategoryRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.GroupName))
-        {
-            return BadRequest("name and groupName are required.");
-        }
-
-        if (request.PlannedAmount < 0)
-        {
-            return BadRequest("plannedAmount must be greater than or equal to zero.");
-        }
-
-        var normalizedName = CategoryNames.Normalize(request.Name);
-        var normalizedGroupName = GroupNames.Normalize(request.GroupName);
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == categoryId);
-        if (category is null)
-        {
-            return NotFound();
-        }
-
-        var alreadyExists = month.CategoryBudgets
-            .Any(x => x.Id != categoryId && string.Equals(x.Name, normalizedName, StringComparison.OrdinalIgnoreCase));
-
-        if (alreadyExists)
-        {
-            return Conflict("Category name already exists for this month.");
-        }
-
-        category.Name = normalizedName;
-        category.GroupName = normalizedGroupName;
-        category.PlannedAmount = decimal.Round(request.PlannedAmount, 2);
-
-        if (request.DisplayOrder is not null)
-        {
-            category.DisplayOrder = request.DisplayOrder.Value;
-        }
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToBudgetResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await budgetService.UpdateCategoryAsync(monthId, categoryId, request, ct));
 
     [HttpDelete("categories/{categoryId:guid}")]
     public async Task<ActionResult<BudgetResponseDto>> DeleteCategory(
         Guid monthId,
         Guid categoryId,
-        CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == categoryId);
-        if (category is null)
-        {
-            return NotFound();
-        }
-
-        var hasEntries = await dbContext.Entries.AnyAsync(x => x.CategoryBudgetId == categoryId, cancellationToken);
-        if (hasEntries)
-        {
-            return Conflict("Cannot delete category with entries.");
-        }
-
-        dbContext.CategoryBudgets.Remove(category);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToBudgetResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await budgetService.DeleteCategoryAsync(monthId, categoryId, ct));
 }

--- a/backend/CostTracker.Api/Controllers/DashboardController.cs
+++ b/backend/CostTracker.Api/Controllers/DashboardController.cs
@@ -1,29 +1,14 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Api.Services;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/months/{monthId:guid}/dashboard")]
-public class DashboardController(
-    CostTrackerDbContext dbContext,
-    MonthProjectionService projectionService) : ControllerBase
+public class DashboardController(DashboardService dashboardService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<DashboardDto>> GetDashboard(Guid monthId, CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        return Ok(projectionService.ToDashboard(month));
-    }
+    public async Task<ActionResult<DashboardDto>> GetDashboard(Guid monthId, CancellationToken ct)
+        => Ok(await dashboardService.GetDashboardAsync(monthId, ct));
 }

--- a/backend/CostTracker.Api/Controllers/EntriesController.cs
+++ b/backend/CostTracker.Api/Controllers/EntriesController.cs
@@ -1,180 +1,36 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Api.Services;
-using CostTracker.Domain.Entities;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/months/{monthId:guid}/entries")]
-public class EntriesController(
-    CostTrackerDbContext dbContext,
-    MonthProjectionService projectionService) : ControllerBase
+public class EntriesController(EntryService entryService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<EntriesResponseDto>> GetEntries(Guid monthId, CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        return Ok(projectionService.ToEntriesResponse(month));
-    }
+    public async Task<ActionResult<EntriesResponseDto>> GetEntries(Guid monthId, CancellationToken ct)
+        => Ok(await entryService.GetEntriesAsync(monthId, ct));
 
     [HttpPost]
     public async Task<ActionResult<EntriesResponseDto>> CreateEntry(
         Guid monthId,
         [FromBody] CreateEntryRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (request.Amount < 0)
-        {
-            return BadRequest("amount must be greater than or equal to zero.");
-        }
-
-        if (string.IsNullOrWhiteSpace(request.Description))
-        {
-            return BadRequest("description is required.");
-        }
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == request.CategoryBudgetId);
-        if (category is null)
-        {
-            return BadRequest("categoryBudgetId does not belong to this month.");
-        }
-
-        var entry = new Entry
-        {
-            Id = Guid.NewGuid(),
-            MonthId = monthId,
-            CategoryBudgetId = request.CategoryBudgetId,
-            EntryDate = request.EntryDate,
-            Description = request.Description.Trim(),
-            Amount = decimal.Round(request.Amount, 2),
-            CreatedAt = DateTimeOffset.UtcNow
-        };
-
-        await dbContext.Entries.AddAsync(entry, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToEntriesResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await entryService.CreateEntryAsync(monthId, request, ct));
 
     [HttpPut("{entryId:guid}")]
     public async Task<ActionResult<EntriesResponseDto>> UpdateEntry(
         Guid monthId,
         Guid entryId,
         [FromBody] UpdateEntryRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (request.Amount < 0)
-        {
-            return BadRequest("amount must be greater than or equal to zero.");
-        }
-
-        if (string.IsNullOrWhiteSpace(request.Description))
-        {
-            return BadRequest("description is required.");
-        }
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var entry = month.Entries.FirstOrDefault(x => x.Id == entryId);
-        if (entry is null)
-        {
-            return NotFound();
-        }
-
-        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == request.CategoryBudgetId);
-        if (category is null)
-        {
-            return BadRequest("categoryBudgetId does not belong to this month.");
-        }
-
-        entry.CategoryBudgetId = request.CategoryBudgetId;
-        entry.EntryDate = request.EntryDate;
-        entry.Description = request.Description.Trim();
-        entry.Amount = decimal.Round(request.Amount, 2);
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToEntriesResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await entryService.UpdateEntryAsync(monthId, entryId, request, ct));
 
     [HttpDelete("{entryId:guid}")]
     public async Task<ActionResult<EntriesResponseDto>> DeleteEntry(
         Guid monthId,
         Guid entryId,
-        CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        var entry = month.Entries.FirstOrDefault(x => x.Id == entryId);
-        if (entry is null)
-        {
-            return NotFound();
-        }
-
-        dbContext.Entries.Remove(entry);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToEntriesResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await entryService.DeleteEntryAsync(monthId, entryId, ct));
 }

--- a/backend/CostTracker.Api/Controllers/FinancialHealthController.cs
+++ b/backend/CostTracker.Api/Controllers/FinancialHealthController.cs
@@ -1,47 +1,20 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Domain.Entities;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/financial-health/profile")]
-public class FinancialHealthController(CostTrackerDbContext dbContext) : ControllerBase
+public class FinancialHealthController(FinancialHealthService financialHealthService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<HealthProfileDto>> GetProfile(CancellationToken cancellationToken)
-    {
-        var profile = await dbContext.HealthProfiles.FirstOrDefaultAsync(cancellationToken);
-        if (profile is null)
-            return Ok(new HealthProfileDto(Guid.Empty, 0, 0));
-
-        return Ok(new HealthProfileDto(profile.Id, profile.EssentialExpenses, profile.SavedEmergencyFund));
-    }
+    public async Task<ActionResult<HealthProfileDto>> GetProfile(CancellationToken ct)
+        => Ok(await financialHealthService.GetProfileAsync(ct));
 
     [HttpPut]
     public async Task<ActionResult<HealthProfileDto>> UpsertProfile(
         [FromBody] UpdateHealthProfileRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (request.EssentialExpenses < 0)
-            return BadRequest("essentialExpenses must be >= 0.");
-
-        if (request.SavedEmergencyFund < 0)
-            return BadRequest("savedEmergencyFund must be >= 0.");
-
-        var profile = await dbContext.HealthProfiles.FirstOrDefaultAsync(cancellationToken);
-        if (profile is null)
-        {
-            profile = new HealthProfile { Id = Guid.NewGuid() };
-            await dbContext.HealthProfiles.AddAsync(profile, cancellationToken);
-        }
-
-        profile.EssentialExpenses = decimal.Round(request.EssentialExpenses, 2);
-        profile.SavedEmergencyFund = decimal.Round(request.SavedEmergencyFund, 2);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return Ok(new HealthProfileDto(profile.Id, profile.EssentialExpenses, profile.SavedEmergencyFund));
-    }
+        CancellationToken ct)
+        => Ok(await financialHealthService.UpsertProfileAsync(request, ct));
 }

--- a/backend/CostTracker.Api/Controllers/MonthsController.cs
+++ b/backend/CostTracker.Api/Controllers/MonthsController.cs
@@ -1,168 +1,30 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Api.Services;
-using CostTracker.Domain.Constants;
-using CostTracker.Domain.Entities;
-using CostTracker.Domain.Enums;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/months")]
-public class MonthsController(
-    CostTrackerDbContext dbContext,
-    MonthProjectionService projectionService) : ControllerBase
+public class MonthsController(MonthService monthService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<IReadOnlyList<MonthSummaryDto>>> GetMonths(CancellationToken cancellationToken)
-    {
-        var months = await dbContext.Months
-            .WithDetails()
-            .OrderByDescending(x => x.ReferenceMonth)
-            .ToListAsync(cancellationToken);
-
-        return Ok(months.Select(projectionService.ToMonthSummary).ToList());
-    }
+    public async Task<ActionResult<IReadOnlyList<MonthSummaryDto>>> GetMonths(CancellationToken ct)
+        => Ok(await monthService.GetMonthsAsync(ct));
 
     [HttpPost("new")]
     public async Task<ActionResult<MonthSummaryDto>> CreateNewMonth(
         [FromBody] CreateMonthRequest? request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
-        var openMonth = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Status == MonthStatus.Open, cancellationToken);
-
-        if (openMonth is null)
-        {
-            return NotFound("No OPEN month found to clone.");
-        }
-
-        var desiredReferenceMonth = request?.ReferenceMonth;
-        string nextReferenceMonth;
-
-        if (string.IsNullOrWhiteSpace(desiredReferenceMonth))
-        {
-            nextReferenceMonth = MonthProjectionService.GetNextReferenceMonth(openMonth.ReferenceMonth);
-        }
-        else
-        {
-            if (!MonthProjectionService.TryNormalizeReferenceMonth(desiredReferenceMonth, out nextReferenceMonth))
-            {
-                return BadRequest("referenceMonth must be in format YYYY-MM.");
-            }
-        }
-
-        var exists = await dbContext.Months.AnyAsync(x => x.ReferenceMonth == nextReferenceMonth, cancellationToken);
-        if (exists)
-        {
-            return Conflict($"Month {nextReferenceMonth} already exists.");
-        }
-
-        openMonth.Status = MonthStatus.Closed;
-        openMonth.ClosedAt = DateTimeOffset.UtcNow;
-
-        var newMonthId = Guid.NewGuid();
-        var now = DateTimeOffset.UtcNow;
-
-        var newMonth = new Month
-        {
-            Id = newMonthId,
-            ReferenceMonth = nextReferenceMonth,
-            Salary = openMonth.Salary,
-            Currency = openMonth.Currency,
-            Status = MonthStatus.Open,
-            CreatedAt = now,
-            ClonedFromMonthId = openMonth.Id
-        };
-
-        var newCategories = openMonth.CategoryBudgets
-            .OrderBy(x => x.DisplayOrder)
-            .Select(category => new CategoryBudget
-            {
-                Id = Guid.NewGuid(),
-                MonthId = newMonthId,
-                Name = CategoryNames.Normalize(category.Name),
-                GroupName = GroupNames.Normalize(category.GroupName),
-                PlannedAmount = category.PlannedAmount,
-                DisplayOrder = category.DisplayOrder
-            })
-            .ToList();
-
-        var newTargets = openMonth.GroupTargets
-            .GroupBy(target => GroupNames.Normalize(target.GroupName), StringComparer.OrdinalIgnoreCase)
-            .Select(group =>
-            {
-                var source = group.First();
-
-                return new GroupTarget
-                {
-                    Id = Guid.NewGuid(),
-                    MonthId = newMonthId,
-                    GroupName = GroupNames.Normalize(group.Key),
-                    TargetPercent = source.TargetPercent
-                };
-            })
-            .ToList();
-
-        foreach (var groupName in GroupNames.All)
-        {
-            if (newTargets.Any(target => string.Equals(target.GroupName, groupName, StringComparison.OrdinalIgnoreCase)))
-            {
-                continue;
-            }
-
-            newTargets.Add(new GroupTarget
-            {
-                Id = Guid.NewGuid(),
-                MonthId = newMonthId,
-                GroupName = groupName,
-                TargetPercent = 0m
-            });
-        }
-
-        await dbContext.Months.AddAsync(newMonth, cancellationToken);
-        await dbContext.CategoryBudgets.AddRangeAsync(newCategories, cancellationToken);
-        await dbContext.GroupTargets.AddRangeAsync(newTargets, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var monthWithDetails = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == newMonthId, cancellationToken);
-
-        return Created($"/api/months/{monthWithDetails.Id}", projectionService.ToMonthSummary(monthWithDetails));
+        var result = await monthService.CreateNewMonthAsync(request?.ReferenceMonth, ct);
+        return Created($"/api/months/{result.Id}", result);
     }
 
     [HttpPut("{monthId:guid}/salary")]
     public async Task<ActionResult<MonthSummaryDto>> UpdateSalary(
         Guid monthId,
         [FromBody] UpdateSalaryRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (request.Salary < 0)
-        {
-            return BadRequest("Salary must be greater than or equal to zero.");
-        }
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        month.Salary = decimal.Round(request.Salary, 2);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return Ok(projectionService.ToMonthSummary(month));
-    }
+        CancellationToken ct)
+        => Ok(await monthService.UpdateSalaryAsync(monthId, request.Salary, ct));
 }

--- a/backend/CostTracker.Api/Controllers/PlanningController.cs
+++ b/backend/CostTracker.Api/Controllers/PlanningController.cs
@@ -1,109 +1,31 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Domain.Entities;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/planning/goals")]
-public class PlanningController(CostTrackerDbContext dbContext) : ControllerBase
+public class PlanningController(PlanningService planningService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> GetGoals(CancellationToken cancellationToken)
-    {
-        var goals = await dbContext.PlanningGoals
-            .OrderBy(x => x.CreatedAt)
-            .Select(x => new PlanningGoalDto(x.Id, x.Name, x.TotalAmount, x.SavedAmount, x.Months))
-            .ToListAsync(cancellationToken);
-
-        return Ok(goals);
-    }
+    public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> GetGoals(CancellationToken ct)
+        => Ok(await planningService.GetGoalsAsync(ct));
 
     [HttpPost]
     public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> CreateGoal(
         [FromBody] CreatePlanningGoalRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(request.Name))
-            return BadRequest("name is required.");
-
-        if (request.TotalAmount < 0)
-            return BadRequest("totalAmount must be greater than or equal to zero.");
-
-        if (request.SavedAmount < 0)
-            return BadRequest("savedAmount must be greater than or equal to zero.");
-
-        if (request.SavedAmount > request.TotalAmount)
-            return BadRequest("savedAmount cannot exceed totalAmount.");
-
-        if (request.Months < 1)
-            return BadRequest("months must be at least 1.");
-
-        var goal = new PlanningGoal
-        {
-            Id = Guid.NewGuid(),
-            Name = request.Name.Trim(),
-            TotalAmount = decimal.Round(request.TotalAmount, 2),
-            SavedAmount = decimal.Round(request.SavedAmount, 2),
-            Months = request.Months,
-            CreatedAt = DateTimeOffset.UtcNow
-        };
-
-        await dbContext.PlanningGoals.AddAsync(goal, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return await GetGoals(cancellationToken);
-    }
+        CancellationToken ct)
+        => Ok(await planningService.CreateGoalAsync(request, ct));
 
     [HttpPut("{id:guid}")]
     public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> UpdateGoal(
         Guid id,
         [FromBody] UpdatePlanningGoalRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(request.Name))
-            return BadRequest("name is required.");
-
-        if (request.TotalAmount < 0)
-            return BadRequest("totalAmount must be greater than or equal to zero.");
-
-        if (request.SavedAmount < 0)
-            return BadRequest("savedAmount must be greater than or equal to zero.");
-
-        if (request.SavedAmount > request.TotalAmount)
-            return BadRequest("savedAmount cannot exceed totalAmount.");
-
-        if (request.Months < 1)
-            return BadRequest("months must be at least 1.");
-
-        var goal = await dbContext.PlanningGoals.FindAsync([id], cancellationToken);
-        if (goal is null)
-            return NotFound();
-
-        goal.Name = request.Name.Trim();
-        goal.TotalAmount = decimal.Round(request.TotalAmount, 2);
-        goal.SavedAmount = decimal.Round(request.SavedAmount, 2);
-        goal.Months = request.Months;
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return await GetGoals(cancellationToken);
-    }
+        CancellationToken ct)
+        => Ok(await planningService.UpdateGoalAsync(id, request, ct));
 
     [HttpDelete("{id:guid}")]
-    public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> DeleteGoal(
-        Guid id,
-        CancellationToken cancellationToken)
-    {
-        var goal = await dbContext.PlanningGoals.FindAsync([id], cancellationToken);
-        if (goal is null)
-            return NotFound();
-
-        dbContext.PlanningGoals.Remove(goal);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return await GetGoals(cancellationToken);
-    }
+    public async Task<ActionResult<IReadOnlyList<PlanningGoalDto>>> DeleteGoal(Guid id, CancellationToken ct)
+        => Ok(await planningService.DeleteGoalAsync(id, ct));
 }

--- a/backend/CostTracker.Api/Controllers/TargetsController.cs
+++ b/backend/CostTracker.Api/Controllers/TargetsController.cs
@@ -1,100 +1,21 @@
-using CostTracker.Api.Contracts;
-using CostTracker.Api.Services;
-using CostTracker.Domain.Constants;
-using CostTracker.Domain.Entities;
-using CostTracker.Infrastructure.Persistence;
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Api.Controllers;
 
 [ApiController]
 [Route("api/months/{monthId:guid}/targets")]
-public class TargetsController(
-    CostTrackerDbContext dbContext,
-    MonthProjectionService projectionService) : ControllerBase
+public class TargetsController(TargetsService targetsService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<TargetsResponseDto>> GetTargets(Guid monthId, CancellationToken cancellationToken)
-    {
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        return Ok(projectionService.ToTargetsResponse(month));
-    }
+    public async Task<ActionResult<TargetsResponseDto>> GetTargets(Guid monthId, CancellationToken ct)
+        => Ok(await targetsService.GetTargetsAsync(monthId, ct));
 
     [HttpPut]
     public async Task<ActionResult<TargetsResponseDto>> UpdateTargets(
         Guid monthId,
         [FromBody] UpdateTargetsRequest request,
-        CancellationToken cancellationToken)
-    {
-        if (request.Items.Count == 0)
-        {
-            return BadRequest("At least one target item is required.");
-        }
-
-        var month = await dbContext.Months
-            .WithDetails()
-            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
-
-        if (month is null)
-        {
-            return NotFound();
-        }
-
-        if (!MonthProjectionService.IsOpen(month))
-        {
-            return Conflict("Closed months cannot be edited.");
-        }
-
-        foreach (var item in request.Items)
-        {
-            if (string.IsNullOrWhiteSpace(item.GroupName))
-            {
-                return BadRequest("groupName is required.");
-            }
-
-            if (item.TargetPercent < 0 || item.TargetPercent > 1)
-            {
-                return BadRequest("targetPercent must be between 0 and 1.");
-            }
-
-            var normalizedGroupName = GroupNames.Normalize(item.GroupName);
-            var existing = month.GroupTargets
-                .FirstOrDefault(x => string.Equals(
-                    GroupNames.Normalize(x.GroupName),
-                    normalizedGroupName,
-                    StringComparison.OrdinalIgnoreCase));
-
-            if (existing is null)
-            {
-                month.GroupTargets.Add(new GroupTarget
-                {
-                    Id = Guid.NewGuid(),
-                    MonthId = month.Id,
-                    GroupName = normalizedGroupName,
-                    TargetPercent = decimal.Round(item.TargetPercent, 4)
-                });
-            }
-            else
-            {
-                existing.TargetPercent = decimal.Round(item.TargetPercent, 4);
-            }
-        }
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updatedMonth = await dbContext.Months
-            .WithDetails()
-            .FirstAsync(x => x.Id == monthId, cancellationToken);
-
-        return Ok(projectionService.ToTargetsResponse(updatedMonth));
-    }
+        CancellationToken ct)
+        => Ok(await targetsService.UpdateTargetsAsync(monthId, request, ct));
 }

--- a/backend/CostTracker.Api/CostTracker.Api.csproj
+++ b/backend/CostTracker.Api/CostTracker.Api.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CostTracker.Application\CostTracker.Application.csproj" />
     <ProjectReference Include="..\CostTracker.Domain\CostTracker.Domain.csproj" />
     <ProjectReference Include="..\CostTracker.Infrastructure\CostTracker.Infrastructure.csproj" />
   </ItemGroup>

--- a/backend/CostTracker.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/backend/CostTracker.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,32 @@
+using CostTracker.Application.Exceptions;
+
+namespace CostTracker.Api.Middleware;
+
+public class ExceptionHandlingMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (DomainValidationException ex)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(ex.Message);
+        }
+        catch (NotFoundException ex)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(ex.Message);
+        }
+        catch (ConflictException ex)
+        {
+            context.Response.StatusCode = StatusCodes.Status409Conflict;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(ex.Message);
+        }
+    }
+}

--- a/backend/CostTracker.Api/Program.cs
+++ b/backend/CostTracker.Api/Program.cs
@@ -1,5 +1,8 @@
 using CostTracker.Api.Configuration;
+using CostTracker.Api.Middleware;
 using CostTracker.Api.Services;
+using CostTracker.Application.Projections;
+using CostTracker.Application.Services;
 using CostTracker.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -57,6 +60,13 @@ builder.Services.AddCors(options =>
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddScoped<MonthProjectionService>();
 builder.Services.AddScoped<PasswordHashService>();
+builder.Services.AddScoped<MonthService>();
+builder.Services.AddScoped<BudgetService>();
+builder.Services.AddScoped<EntryService>();
+builder.Services.AddScoped<TargetsService>();
+builder.Services.AddScoped<DashboardService>();
+builder.Services.AddScoped<PlanningService>();
+builder.Services.AddScoped<FinancialHealthService>();
 
 var app = builder.Build();
 
@@ -66,6 +76,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseCors("frontend");
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/backend/CostTracker.Application/Contracts/Contracts.cs
+++ b/backend/CostTracker.Application/Contracts/Contracts.cs
@@ -1,4 +1,4 @@
-namespace CostTracker.Api.Contracts;
+namespace CostTracker.Application.Contracts;
 
 public sealed record MonthSummaryDto(
     Guid Id,

--- a/backend/CostTracker.Application/CostTracker.Application.csproj
+++ b/backend/CostTracker.Application/CostTracker.Application.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CostTracker.Domain\CostTracker.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+  </ItemGroup>
+</Project>

--- a/backend/CostTracker.Application/Exceptions/ConflictException.cs
+++ b/backend/CostTracker.Application/Exceptions/ConflictException.cs
@@ -1,0 +1,3 @@
+namespace CostTracker.Application.Exceptions;
+
+public class ConflictException(string message) : Exception(message);

--- a/backend/CostTracker.Application/Exceptions/DomainValidationException.cs
+++ b/backend/CostTracker.Application/Exceptions/DomainValidationException.cs
@@ -1,0 +1,3 @@
+namespace CostTracker.Application.Exceptions;
+
+public class DomainValidationException(string message) : Exception(message);

--- a/backend/CostTracker.Application/Exceptions/NotFoundException.cs
+++ b/backend/CostTracker.Application/Exceptions/NotFoundException.cs
@@ -1,0 +1,3 @@
+namespace CostTracker.Application.Exceptions;
+
+public class NotFoundException(string message = "Not found.") : Exception(message);

--- a/backend/CostTracker.Application/Interfaces/ICostTrackerDbContext.cs
+++ b/backend/CostTracker.Application/Interfaces/ICostTrackerDbContext.cs
@@ -1,0 +1,15 @@
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Interfaces;
+
+public interface ICostTrackerDbContext
+{
+    DbSet<Month> Months { get; }
+    DbSet<CategoryBudget> CategoryBudgets { get; }
+    DbSet<Entry> Entries { get; }
+    DbSet<GroupTarget> GroupTargets { get; }
+    DbSet<PlanningGoal> PlanningGoals { get; }
+    DbSet<HealthProfile> HealthProfiles { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/backend/CostTracker.Application/Projections/MonthProjectionService.cs
+++ b/backend/CostTracker.Application/Projections/MonthProjectionService.cs
@@ -1,10 +1,10 @@
 using System.Globalization;
-using CostTracker.Api.Contracts;
+using CostTracker.Application.Contracts;
 using CostTracker.Domain.Calculations;
 using CostTracker.Domain.Entities;
 using CostTracker.Domain.Enums;
 
-namespace CostTracker.Api.Services;
+namespace CostTracker.Application.Projections;
 
 public class MonthProjectionService
 {

--- a/backend/CostTracker.Application/Projections/MonthQueryExtensions.cs
+++ b/backend/CostTracker.Application/Projections/MonthQueryExtensions.cs
@@ -1,7 +1,7 @@
 using CostTracker.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace CostTracker.Api.Services;
+namespace CostTracker.Application.Projections;
 
 public static class MonthQueryExtensions
 {

--- a/backend/CostTracker.Application/Services/BudgetService.cs
+++ b/backend/CostTracker.Application/Services/BudgetService.cs
@@ -1,0 +1,151 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Projections;
+using CostTracker.Domain.Constants;
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class BudgetService(ICostTrackerDbContext dbContext, MonthProjectionService projectionService)
+{
+    public async Task<BudgetResponseDto> GetBudgetAsync(Guid monthId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        return projectionService.ToBudgetResponse(month);
+    }
+
+    public async Task<BudgetResponseDto> CreateCategoryAsync(
+        Guid monthId,
+        CreateCategoryRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.GroupName))
+            throw new DomainValidationException("name and groupName are required.");
+
+        if (request.PlannedAmount < 0)
+            throw new DomainValidationException("plannedAmount must be greater than or equal to zero.");
+
+        var normalizedName = CategoryNames.Normalize(request.Name);
+        var normalizedGroupName = GroupNames.Normalize(request.GroupName);
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        if (month.CategoryBudgets.Any(x => string.Equals(x.Name, normalizedName, StringComparison.OrdinalIgnoreCase)))
+            throw new ConflictException("Category name already exists for this month.");
+
+        var displayOrder = request.DisplayOrder ?? month.CategoryBudgets.Select(x => x.DisplayOrder).DefaultIfEmpty(0).Max() + 1;
+
+        var category = new CategoryBudget
+        {
+            Id = Guid.NewGuid(),
+            MonthId = monthId,
+            Name = normalizedName,
+            GroupName = normalizedGroupName,
+            PlannedAmount = decimal.Round(request.PlannedAmount, 2),
+            DisplayOrder = displayOrder
+        };
+
+        await dbContext.CategoryBudgets.AddAsync(category, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToBudgetResponse(updatedMonth);
+    }
+
+    public async Task<BudgetResponseDto> UpdateCategoryAsync(
+        Guid monthId,
+        Guid categoryId,
+        UpdateCategoryRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.GroupName))
+            throw new DomainValidationException("name and groupName are required.");
+
+        if (request.PlannedAmount < 0)
+            throw new DomainValidationException("plannedAmount must be greater than or equal to zero.");
+
+        var normalizedName = CategoryNames.Normalize(request.Name);
+        var normalizedGroupName = GroupNames.Normalize(request.GroupName);
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == categoryId);
+        if (category is null)
+            throw new NotFoundException();
+
+        if (month.CategoryBudgets.Any(x => x.Id != categoryId && string.Equals(x.Name, normalizedName, StringComparison.OrdinalIgnoreCase)))
+            throw new ConflictException("Category name already exists for this month.");
+
+        category.Name = normalizedName;
+        category.GroupName = normalizedGroupName;
+        category.PlannedAmount = decimal.Round(request.PlannedAmount, 2);
+
+        if (request.DisplayOrder is not null)
+            category.DisplayOrder = request.DisplayOrder.Value;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToBudgetResponse(updatedMonth);
+    }
+
+    public async Task<BudgetResponseDto> DeleteCategoryAsync(Guid monthId, Guid categoryId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == categoryId);
+        if (category is null)
+            throw new NotFoundException();
+
+        var hasEntries = await dbContext.Entries.AnyAsync(x => x.CategoryBudgetId == categoryId, cancellationToken);
+        if (hasEntries)
+            throw new ConflictException("Cannot delete category with entries.");
+
+        dbContext.CategoryBudgets.Remove(category);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToBudgetResponse(updatedMonth);
+    }
+}

--- a/backend/CostTracker.Application/Services/DashboardService.cs
+++ b/backend/CostTracker.Application/Services/DashboardService.cs
@@ -1,0 +1,22 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Projections;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class DashboardService(ICostTrackerDbContext dbContext, MonthProjectionService projectionService)
+{
+    public async Task<DashboardDto> GetDashboardAsync(Guid monthId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        return projectionService.ToDashboard(month);
+    }
+}

--- a/backend/CostTracker.Application/Services/EntryService.cs
+++ b/backend/CostTracker.Application/Services/EntryService.cs
@@ -1,0 +1,132 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Projections;
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class EntryService(ICostTrackerDbContext dbContext, MonthProjectionService projectionService)
+{
+    public async Task<EntriesResponseDto> GetEntriesAsync(Guid monthId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        return projectionService.ToEntriesResponse(month);
+    }
+
+    public async Task<EntriesResponseDto> CreateEntryAsync(Guid monthId, CreateEntryRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Amount < 0)
+            throw new DomainValidationException("amount must be greater than or equal to zero.");
+
+        if (string.IsNullOrWhiteSpace(request.Description))
+            throw new DomainValidationException("description is required.");
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == request.CategoryBudgetId);
+        if (category is null)
+            throw new DomainValidationException("categoryBudgetId does not belong to this month.");
+
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            MonthId = monthId,
+            CategoryBudgetId = request.CategoryBudgetId,
+            EntryDate = request.EntryDate,
+            Description = request.Description.Trim(),
+            Amount = decimal.Round(request.Amount, 2),
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await dbContext.Entries.AddAsync(entry, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToEntriesResponse(updatedMonth);
+    }
+
+    public async Task<EntriesResponseDto> UpdateEntryAsync(Guid monthId, Guid entryId, UpdateEntryRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Amount < 0)
+            throw new DomainValidationException("amount must be greater than or equal to zero.");
+
+        if (string.IsNullOrWhiteSpace(request.Description))
+            throw new DomainValidationException("description is required.");
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        var entry = month.Entries.FirstOrDefault(x => x.Id == entryId);
+        if (entry is null)
+            throw new NotFoundException();
+
+        var category = month.CategoryBudgets.FirstOrDefault(x => x.Id == request.CategoryBudgetId);
+        if (category is null)
+            throw new DomainValidationException("categoryBudgetId does not belong to this month.");
+
+        entry.CategoryBudgetId = request.CategoryBudgetId;
+        entry.EntryDate = request.EntryDate;
+        entry.Description = request.Description.Trim();
+        entry.Amount = decimal.Round(request.Amount, 2);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToEntriesResponse(updatedMonth);
+    }
+
+    public async Task<EntriesResponseDto> DeleteEntryAsync(Guid monthId, Guid entryId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        var entry = month.Entries.FirstOrDefault(x => x.Id == entryId);
+        if (entry is null)
+            throw new NotFoundException();
+
+        dbContext.Entries.Remove(entry);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToEntriesResponse(updatedMonth);
+    }
+}

--- a/backend/CostTracker.Application/Services/FinancialHealthService.cs
+++ b/backend/CostTracker.Application/Services/FinancialHealthService.cs
@@ -1,0 +1,41 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class FinancialHealthService(ICostTrackerDbContext dbContext)
+{
+    public async Task<HealthProfileDto> GetProfileAsync(CancellationToken cancellationToken)
+    {
+        var profile = await dbContext.HealthProfiles.FirstOrDefaultAsync(cancellationToken);
+        if (profile is null)
+            return new HealthProfileDto(Guid.Empty, 0, 0);
+
+        return new HealthProfileDto(profile.Id, profile.EssentialExpenses, profile.SavedEmergencyFund);
+    }
+
+    public async Task<HealthProfileDto> UpsertProfileAsync(UpdateHealthProfileRequest request, CancellationToken cancellationToken)
+    {
+        if (request.EssentialExpenses < 0)
+            throw new DomainValidationException("essentialExpenses must be >= 0.");
+
+        if (request.SavedEmergencyFund < 0)
+            throw new DomainValidationException("savedEmergencyFund must be >= 0.");
+
+        var profile = await dbContext.HealthProfiles.FirstOrDefaultAsync(cancellationToken);
+        if (profile is null)
+        {
+            profile = new HealthProfile { Id = Guid.NewGuid() };
+            await dbContext.HealthProfiles.AddAsync(profile, cancellationToken);
+        }
+
+        profile.EssentialExpenses = decimal.Round(request.EssentialExpenses, 2);
+        profile.SavedEmergencyFund = decimal.Round(request.SavedEmergencyFund, 2);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new HealthProfileDto(profile.Id, profile.EssentialExpenses, profile.SavedEmergencyFund);
+    }
+}

--- a/backend/CostTracker.Application/Services/MonthService.cs
+++ b/backend/CostTracker.Application/Services/MonthService.cs
@@ -1,0 +1,139 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Projections;
+using CostTracker.Domain.Constants;
+using CostTracker.Domain.Entities;
+using CostTracker.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class MonthService(ICostTrackerDbContext dbContext, MonthProjectionService projectionService)
+{
+    public async Task<IReadOnlyList<MonthSummaryDto>> GetMonthsAsync(CancellationToken cancellationToken)
+    {
+        var months = await dbContext.Months
+            .WithDetails()
+            .OrderByDescending(x => x.ReferenceMonth)
+            .ToListAsync(cancellationToken);
+
+        return months.Select(projectionService.ToMonthSummary).ToList();
+    }
+
+    public async Task<MonthSummaryDto> CreateNewMonthAsync(string? desiredReferenceMonth, CancellationToken cancellationToken)
+    {
+        var openMonth = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Status == MonthStatus.Open, cancellationToken);
+
+        if (openMonth is null)
+            throw new NotFoundException("No OPEN month found to clone.");
+
+        string nextReferenceMonth;
+        if (string.IsNullOrWhiteSpace(desiredReferenceMonth))
+        {
+            nextReferenceMonth = MonthProjectionService.GetNextReferenceMonth(openMonth.ReferenceMonth);
+        }
+        else
+        {
+            if (!MonthProjectionService.TryNormalizeReferenceMonth(desiredReferenceMonth, out nextReferenceMonth))
+                throw new DomainValidationException("referenceMonth must be in format YYYY-MM.");
+        }
+
+        var exists = await dbContext.Months.AnyAsync(x => x.ReferenceMonth == nextReferenceMonth, cancellationToken);
+        if (exists)
+            throw new ConflictException($"Month {nextReferenceMonth} already exists.");
+
+        openMonth.Status = MonthStatus.Closed;
+        openMonth.ClosedAt = DateTimeOffset.UtcNow;
+
+        var newMonthId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        var newMonth = new Month
+        {
+            Id = newMonthId,
+            ReferenceMonth = nextReferenceMonth,
+            Salary = openMonth.Salary,
+            Currency = openMonth.Currency,
+            Status = MonthStatus.Open,
+            CreatedAt = now,
+            ClonedFromMonthId = openMonth.Id
+        };
+
+        var newCategories = openMonth.CategoryBudgets
+            .OrderBy(x => x.DisplayOrder)
+            .Select(category => new CategoryBudget
+            {
+                Id = Guid.NewGuid(),
+                MonthId = newMonthId,
+                Name = CategoryNames.Normalize(category.Name),
+                GroupName = GroupNames.Normalize(category.GroupName),
+                PlannedAmount = category.PlannedAmount,
+                DisplayOrder = category.DisplayOrder
+            })
+            .ToList();
+
+        var newTargets = openMonth.GroupTargets
+            .GroupBy(target => GroupNames.Normalize(target.GroupName), StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var source = group.First();
+                return new GroupTarget
+                {
+                    Id = Guid.NewGuid(),
+                    MonthId = newMonthId,
+                    GroupName = GroupNames.Normalize(group.Key),
+                    TargetPercent = source.TargetPercent
+                };
+            })
+            .ToList();
+
+        foreach (var groupName in GroupNames.All)
+        {
+            if (newTargets.Any(target => string.Equals(target.GroupName, groupName, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            newTargets.Add(new GroupTarget
+            {
+                Id = Guid.NewGuid(),
+                MonthId = newMonthId,
+                GroupName = groupName,
+                TargetPercent = 0m
+            });
+        }
+
+        await dbContext.Months.AddAsync(newMonth, cancellationToken);
+        await dbContext.CategoryBudgets.AddRangeAsync(newCategories, cancellationToken);
+        await dbContext.GroupTargets.AddRangeAsync(newTargets, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var monthWithDetails = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == newMonthId, cancellationToken);
+
+        return projectionService.ToMonthSummary(monthWithDetails);
+    }
+
+    public async Task<MonthSummaryDto> UpdateSalaryAsync(Guid monthId, decimal salary, CancellationToken cancellationToken)
+    {
+        if (salary < 0)
+            throw new DomainValidationException("Salary must be greater than or equal to zero.");
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        month.Salary = decimal.Round(salary, 2);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return projectionService.ToMonthSummary(month);
+    }
+}

--- a/backend/CostTracker.Application/Services/PlanningService.cs
+++ b/backend/CostTracker.Application/Services/PlanningService.cs
@@ -1,0 +1,94 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class PlanningService(ICostTrackerDbContext dbContext)
+{
+    public async Task<IReadOnlyList<PlanningGoalDto>> GetGoalsAsync(CancellationToken cancellationToken)
+    {
+        return await dbContext.PlanningGoals
+            .OrderBy(x => x.CreatedAt)
+            .Select(x => new PlanningGoalDto(x.Id, x.Name, x.TotalAmount, x.SavedAmount, x.Months))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<PlanningGoalDto>> CreateGoalAsync(CreatePlanningGoalRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new DomainValidationException("name is required.");
+
+        if (request.TotalAmount < 0)
+            throw new DomainValidationException("totalAmount must be greater than or equal to zero.");
+
+        if (request.SavedAmount < 0)
+            throw new DomainValidationException("savedAmount must be greater than or equal to zero.");
+
+        if (request.SavedAmount > request.TotalAmount)
+            throw new DomainValidationException("savedAmount cannot exceed totalAmount.");
+
+        if (request.Months < 1)
+            throw new DomainValidationException("months must be at least 1.");
+
+        var goal = new PlanningGoal
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name.Trim(),
+            TotalAmount = decimal.Round(request.TotalAmount, 2),
+            SavedAmount = decimal.Round(request.SavedAmount, 2),
+            Months = request.Months,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await dbContext.PlanningGoals.AddAsync(goal, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return await GetGoalsAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<PlanningGoalDto>> UpdateGoalAsync(Guid id, UpdatePlanningGoalRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new DomainValidationException("name is required.");
+
+        if (request.TotalAmount < 0)
+            throw new DomainValidationException("totalAmount must be greater than or equal to zero.");
+
+        if (request.SavedAmount < 0)
+            throw new DomainValidationException("savedAmount must be greater than or equal to zero.");
+
+        if (request.SavedAmount > request.TotalAmount)
+            throw new DomainValidationException("savedAmount cannot exceed totalAmount.");
+
+        if (request.Months < 1)
+            throw new DomainValidationException("months must be at least 1.");
+
+        var goal = await dbContext.PlanningGoals.FindAsync([id], cancellationToken);
+        if (goal is null)
+            throw new NotFoundException();
+
+        goal.Name = request.Name.Trim();
+        goal.TotalAmount = decimal.Round(request.TotalAmount, 2);
+        goal.SavedAmount = decimal.Round(request.SavedAmount, 2);
+        goal.Months = request.Months;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return await GetGoalsAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<PlanningGoalDto>> DeleteGoalAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var goal = await dbContext.PlanningGoals.FindAsync([id], cancellationToken);
+        if (goal is null)
+            throw new NotFoundException();
+
+        dbContext.PlanningGoals.Remove(goal);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return await GetGoalsAsync(cancellationToken);
+    }
+}

--- a/backend/CostTracker.Application/Services/TargetsService.cs
+++ b/backend/CostTracker.Application/Services/TargetsService.cs
@@ -1,0 +1,79 @@
+using CostTracker.Application.Contracts;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Projections;
+using CostTracker.Domain.Constants;
+using CostTracker.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CostTracker.Application.Services;
+
+public class TargetsService(ICostTrackerDbContext dbContext, MonthProjectionService projectionService)
+{
+    public async Task<TargetsResponseDto> GetTargetsAsync(Guid monthId, CancellationToken cancellationToken)
+    {
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        return projectionService.ToTargetsResponse(month);
+    }
+
+    public async Task<TargetsResponseDto> UpdateTargetsAsync(Guid monthId, UpdateTargetsRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Items.Count == 0)
+            throw new DomainValidationException("At least one target item is required.");
+
+        var month = await dbContext.Months
+            .WithDetails()
+            .FirstOrDefaultAsync(x => x.Id == monthId, cancellationToken);
+
+        if (month is null)
+            throw new NotFoundException();
+
+        if (!MonthProjectionService.IsOpen(month))
+            throw new ConflictException("Closed months cannot be edited.");
+
+        foreach (var item in request.Items)
+        {
+            if (string.IsNullOrWhiteSpace(item.GroupName))
+                throw new DomainValidationException("groupName is required.");
+
+            if (item.TargetPercent < 0 || item.TargetPercent > 1)
+                throw new DomainValidationException("targetPercent must be between 0 and 1.");
+
+            var normalizedGroupName = GroupNames.Normalize(item.GroupName);
+            var existing = month.GroupTargets
+                .FirstOrDefault(x => string.Equals(
+                    GroupNames.Normalize(x.GroupName),
+                    normalizedGroupName,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (existing is null)
+            {
+                month.GroupTargets.Add(new GroupTarget
+                {
+                    Id = Guid.NewGuid(),
+                    MonthId = month.Id,
+                    GroupName = normalizedGroupName,
+                    TargetPercent = decimal.Round(item.TargetPercent, 4)
+                });
+            }
+            else
+            {
+                existing.TargetPercent = decimal.Round(item.TargetPercent, 4);
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var updatedMonth = await dbContext.Months
+            .WithDetails()
+            .FirstAsync(x => x.Id == monthId, cancellationToken);
+
+        return projectionService.ToTargetsResponse(updatedMonth);
+    }
+}

--- a/backend/CostTracker.Infrastructure/CostTracker.Infrastructure.csproj
+++ b/backend/CostTracker.Infrastructure/CostTracker.Infrastructure.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CostTracker.Domain\CostTracker.Domain.csproj" />
+    <ProjectReference Include="..\CostTracker.Application\CostTracker.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/CostTracker.Infrastructure/Extensions/DependencyInjectionExtensions.cs
+++ b/backend/CostTracker.Infrastructure/Extensions/DependencyInjectionExtensions.cs
@@ -1,3 +1,4 @@
+using CostTracker.Application.Interfaces;
 using CostTracker.Infrastructure.Persistence;
 using CostTracker.Infrastructure.Seed;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +20,7 @@ public static class DependencyInjectionExtensions
                 npgsql.MigrationsAssembly(typeof(CostTrackerDbContext).Assembly.FullName);
             }));
 
+        services.AddScoped<ICostTrackerDbContext>(sp => sp.GetRequiredService<CostTrackerDbContext>());
         services.AddScoped<DatabaseSeeder>();
         services.AddScoped<CanonicalDataBackfillService>();
 

--- a/backend/CostTracker.Infrastructure/Persistence/CostTrackerDbContext.cs
+++ b/backend/CostTracker.Infrastructure/Persistence/CostTrackerDbContext.cs
@@ -1,10 +1,11 @@
+using CostTracker.Application.Interfaces;
 using CostTracker.Domain.Entities;
 using CostTracker.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 
 namespace CostTracker.Infrastructure.Persistence;
 
-public class CostTrackerDbContext(DbContextOptions<CostTrackerDbContext> options) : DbContext(options)
+public class CostTrackerDbContext(DbContextOptions<CostTrackerDbContext> options) : DbContext(options), ICostTrackerDbContext
 {
     public DbSet<Month> Months => Set<Month>();
     public DbSet<CategoryBudget> CategoryBudgets => Set<CategoryBudget>();

--- a/backend/CostTracker.Tests/CostTracker.Tests.csproj
+++ b/backend/CostTracker.Tests/CostTracker.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CostTracker.Application\CostTracker.Application.csproj" />
     <ProjectReference Include="..\CostTracker.Api\CostTracker.Api.csproj" />
     <ProjectReference Include="..\CostTracker.Domain\CostTracker.Domain.csproj" />
     <ProjectReference Include="..\CostTracker.Infrastructure\CostTracker.Infrastructure.csproj" />

--- a/backend/CostTracker.Tests/Integration/ApiFlowTests.cs
+++ b/backend/CostTracker.Tests/Integration/ApiFlowTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using CostTracker.Api.Contracts;
+using CostTracker.Application.Contracts;
 using CostTracker.Domain.Constants;
 
 namespace CostTracker.Tests.Integration;

--- a/backend/CostTracker.sln
+++ b/backend/CostTracker.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CostTracker.Infrastructure"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CostTracker.Tests", "CostTracker.Tests\CostTracker.Tests.csproj", "{9E3170D5-5E8C-4AE3-93CA-E09771A4CDDD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CostTracker.Application", "CostTracker.Application\CostTracker.Application.csproj", "{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{9E3170D5-5E8C-4AE3-93CA-E09771A4CDDD}.Release|x64.Build.0 = Release|Any CPU
 		{9E3170D5-5E8C-4AE3-93CA-E09771A4CDDD}.Release|x86.ActiveCfg = Release|Any CPU
 		{9E3170D5-5E8C-4AE3-93CA-E09771A4CDDD}.Release|x86.Build.0 = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Debug|x86.Build.0 = Debug|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|x64.Build.0 = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|x86.ActiveCfg = Release|Any CPU
+		{6B6014CA-47D1-4B2B-AFA8-CA816EB7FDC5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- Adds `CostTracker.Application` project with `ICostTrackerDbContext` interface, domain exceptions (`NotFoundException`, `ConflictException`, `DomainValidationException`), 7 application service classes, and moves `Contracts` + `MonthProjectionService`/`MonthQueryExtensions` projections from Api
- Infrastructure's `CostTrackerDbContext` now implements `ICostTrackerDbContext`; DI registers the interface
- All 7 feature controllers refactored to thin HTTP adapters (one-liner actions); `ExceptionHandlingMiddleware` maps domain exceptions to 400/404/409 responses, eliminating all inline error returns from controllers

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test` — 11/11 passing
- [ ] Manual smoke test: negative salary → 400, invalid monthId → 404, duplicate month → 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)