### PR TITLE
feat(ai): retry com backoff em 503/429 do Gemini + bump default model

### DIFF
--- a/backend/CostTracker.Api/appsettings.json
+++ b/backend/CostTracker.Api/appsettings.json
@@ -11,6 +11,6 @@
   "AllowedHosts": "*",
   "Gemini": {
     "ApiKey": "",
-    "Model": "gemini-2.5-pro"
+    "Model": "gemini-3.1-pro-preview"
   }
 }

--- a/backend/CostTracker.Application/Integrations/Gemini/GeminiClient.cs
+++ b/backend/CostTracker.Application/Integrations/Gemini/GeminiClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -24,12 +25,28 @@ public class GeminiClient(HttpClient http, IOptions<GeminiOptions> opts) : IGemi
             new GeminiGenerationConfig(0.7f)
         );
 
-        var response = await http.PostAsJsonAsync(url, requestBody, JsonOpts, ct);
+        HttpResponseMessage response = null!;
+        string lastError = "";
 
-        if (!response.IsSuccessStatusCode)
+        for (var attempt = 0; attempt <= options.MaxRetries; attempt++)
         {
-            var error = await response.Content.ReadAsStringAsync(ct);
-            throw new ConflictException($"Falha ao gerar análise (Gemini {response.StatusCode}): {error}");
+            response = await http.PostAsJsonAsync(url, requestBody, JsonOpts, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                break;
+            }
+
+            lastError = await response.Content.ReadAsStringAsync(ct);
+
+            if (!IsTransient(response.StatusCode) || attempt == options.MaxRetries)
+            {
+                throw new ConflictException($"Falha ao gerar análise (Gemini {response.StatusCode}): {lastError}");
+            }
+
+            response.Dispose();
+            var delayMs = options.InitialBackoffMs * (1 << attempt);
+            await Task.Delay(delayMs, ct);
         }
 
         var result = await response.Content.ReadFromJsonAsync<GeminiResponse>(JsonOpts, ct)
@@ -38,6 +55,9 @@ public class GeminiClient(HttpClient http, IOptions<GeminiOptions> opts) : IGemi
         return result.Candidates?[0]?.Content?.Parts?[0]?.Text
             ?? throw new ConflictException("Gemini não retornou texto na resposta.");
     }
+
+    private static bool IsTransient(HttpStatusCode status) =>
+        status == HttpStatusCode.ServiceUnavailable || status == HttpStatusCode.TooManyRequests;
 
     private record GeminiRequest(
         [property: JsonPropertyName("contents")] List<GeminiContent> Contents,

--- a/backend/CostTracker.Application/Options/GeminiOptions.cs
+++ b/backend/CostTracker.Application/Options/GeminiOptions.cs
@@ -5,4 +5,6 @@ public class GeminiOptions
     public string ApiKey { get; set; } = "";
     public string Model { get; set; } = "gemini-2.5-pro-preview-03-25";
     public string BaseUrl { get; set; } = "https://generativelanguage.googleapis.com";
+    public int MaxRetries { get; set; } = 3;
+    public int InitialBackoffMs { get; set; } = 1000;
 }

--- a/backend/CostTracker.Tests/Integrations/GeminiClientRetryTests.cs
+++ b/backend/CostTracker.Tests/Integrations/GeminiClientRetryTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text;
+using CostTracker.Application.Exceptions;
+using CostTracker.Application.Integrations.Gemini;
+using CostTracker.Application.Options;
+using Microsoft.Extensions.Options;
+
+namespace CostTracker.Tests.Integrations;
+
+public class GeminiClientRetryTests
+{
+    private static GeminiOptions FastRetryOptions(int maxRetries = 3) => new()
+    {
+        ApiKey = "fake",
+        Model = "fake-model",
+        BaseUrl = "https://example.test",
+        MaxRetries = maxRetries,
+        InitialBackoffMs = 1
+    };
+
+    [Fact]
+    public async Task GenerateAnalysisAsync_RetriesOn503AndSucceeds()
+    {
+        var handler = new QueuedHandler(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("busy") },
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("busy") },
+            BuildSuccess("ok response")
+        );
+
+        var client = new GeminiClient(new HttpClient(handler), Options.Create(FastRetryOptions()));
+
+        var result = await client.GenerateAnalysisAsync("ping", CancellationToken.None);
+
+        Assert.Equal("ok response", result);
+        Assert.Equal(3, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GenerateAnalysisAsync_RetriesOn429AndSucceeds()
+    {
+        var handler = new QueuedHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests) { Content = new StringContent("limit") },
+            BuildSuccess("ok")
+        );
+
+        var client = new GeminiClient(new HttpClient(handler), Options.Create(FastRetryOptions()));
+
+        var result = await client.GenerateAnalysisAsync("ping", CancellationToken.None);
+
+        Assert.Equal("ok", result);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GenerateAnalysisAsync_DoesNotRetryOn400()
+    {
+        var handler = new QueuedHandler(
+            new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("bad") }
+        );
+
+        var client = new GeminiClient(new HttpClient(handler), Options.Create(FastRetryOptions()));
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            client.GenerateAnalysisAsync("ping", CancellationToken.None));
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GenerateAnalysisAsync_ThrowsAfterExhaustingRetries()
+    {
+        var handler = new QueuedHandler(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("busy") },
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("busy") },
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent("busy") }
+        );
+
+        var client = new GeminiClient(new HttpClient(handler), Options.Create(FastRetryOptions(maxRetries: 2)));
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            client.GenerateAnalysisAsync("ping", CancellationToken.None));
+        Assert.Equal(3, handler.CallCount);
+    }
+
+    private static HttpResponseMessage BuildSuccess(string text) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(
+            "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + text + "\"}]}}]}",
+            Encoding.UTF8,
+            "application/json")
+    };
+
+    private sealed class QueuedHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _queue = new(responses);
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(_queue.Dequeue());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Retry com backoff exponencial em `GeminiClient` para respostas 503 (UNAVAILABLE) e 429 (rate limit) — cobre o transitório de modelos preview do Gemini sob alta demanda.
- Configurável via `GeminiOptions.MaxRetries` (default 3) e `GeminiOptions.InitialBackoffMs` (default 1000ms). Backoff: `initial * 2^attempt`.
- Sobe o modelo default em `appsettings.json` para `gemini-3.1-pro-preview` (mais capaz para análise financeira), agora que o 503 transitório está coberto.

## Test plan
- [x] Suíte unitária verde: 17/17 (4 testes novos cobrindo 503, 429, não-retry em 400, exhaustão).
- [ ] Smoke em produção: clicar no botão de análise e ver o retry segurar o 503 ocasional.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)