### PR TITLE
feat(ai): adapt analysis prompt to month stage

### DIFF
--- a/backend/CostTracker.Application/Contracts/AnalysisInput.cs
+++ b/backend/CostTracker.Application/Contracts/AnalysisInput.cs
@@ -27,5 +27,6 @@ internal sealed record AnalysisGroupTarget(
 
 internal sealed record AnalysisInput(
     AnalysisMonthSnapshot CurrentMonth,
-    IReadOnlyList<AnalysisMonthSnapshot> History
+    IReadOnlyList<AnalysisMonthSnapshot> History,
+    DateOnly AnalysisDate
 );

--- a/backend/CostTracker.Application/Services/AiAnalysisService.cs
+++ b/backend/CostTracker.Application/Services/AiAnalysisService.cs
@@ -31,7 +31,8 @@ public class AiAnalysisService(
 
         var input = new AnalysisInput(
             BuildSnapshot(current),
-            history.Select(BuildSnapshot).ToList()
+            history.Select(BuildSnapshot).ToList(),
+            DateOnly.FromDateTime(DateTime.UtcNow)
         );
 
         var userPrompt = AnalysisPromptBuilder.BuildUser(input);

--- a/backend/CostTracker.Application/Services/AnalysisPromptBuilder.cs
+++ b/backend/CostTracker.Application/Services/AnalysisPromptBuilder.cs
@@ -24,45 +24,71 @@ internal static class AnalysisPromptBuilder
         - Markdown, with the section headings below in this exact order
         - Begin directly with the first heading; no greeting, no preamble
 
-        Required sections (use these exact headings):
+        STAGE DETECTION (read this first):
+        The JSON includes `dataAnalise` (today) and `mesAtual.referencia` (the analyzed month, format YYYY-MM). Determine the stage:
+        - CLOSED: dataAnalise is after the last day of mesAtual.referencia → the month is fully closed; do a complete retrospective.
+        - ONGOING: dataAnalise falls within mesAtual.referencia → the month is in progress; compute progress = (day of dataAnalise) / (days in that month) and classify:
+          * EARLY (progress < 35%): little real spending data yet
+          * MID (35% ≤ progress < 70%): partial data
+          * LATE (progress ≥ 70%): near-complete data
+        - FUTURE: dataAnalise is before mesAtual.referencia → treat as a planning-only forecast (rare).
+
+        Adapt the analysis to the stage. Always state the stage and the elapsed days explicitly in "Resumo Executivo" so the reader knows the basis of the report. Never claim a category overspent on the basis of partial data — for ONGOING months, always reason in terms of run-rate (gasto / progress) versus planned.
+
+        Required sections (use these exact headings, in this order):
 
         # Resumo Executivo
-        3-4 sentences: state the savings rate (= salary − totalGasto, as % of salary, one decimal) and whether group targets were met.
+        3-4 sentences. Open by stating the stage (e.g., "Mês em curso, dia 8 de 30 — 27% decorrido" or "Mês fechado"). Then state the savings rate (CLOSED) or projected savings rate (ONGOING/FUTURE), and whether group targets are on track.
 
         # Análise do Mês Atual
-        Per category group: how it performed vs planned. For the categories with the largest absolute or percentage deviation, give the deviation in € and %.
+        - CLOSED: per category group, performance vs planned with € and % deviations for the largest movers.
+        - ONGOING: report run-rate per group (gasto-até-agora extrapolado para o mês inteiro = gasto / progress) and compare with planned. Flag categories whose run-rate already exceeds the plan. If progress < 15%, keep this section short and explicitly note that data is too thin for category-level conclusions.
+        - FUTURE: skip detailed category analysis; instead summarize the planned distribution.
 
         # Status das Metas por Grupo
-        For each group with a defined target: state below / at / above target, and explain the cause based on the data (which categories drove it).
+        For each group with a defined target: state below / at / above target.
+        - CLOSED: explain the cause based on actuals.
+        - ONGOING: state whether the current run-rate keeps the group within target. Use `metasPorGrupo[].gastoPercent` directly when meaningful, but always relate it to month progress.
+        - If a group has no target, omit it.
 
         # Tendências Históricas
-        Compare the current month with the prior months in the data. Identify trend direction (increasing / stable / decreasing) per category group. Where useful, give the average monthly spend.
+        Compare with the prior months in `historico`. Identify trend direction per category group (increasing / stable / decreasing). Give the average monthly spend where useful. This section works regardless of stage and should be one of the strongest parts of an EARLY-stage report.
 
         # Saúde Financeira e Taxa de Poupança
-        Compute the savings rate. Compare against the 50/30/20 rule (20% savings target) adapted for Eurozone households. Comment on financial resilience.
+        - CLOSED: actual savings rate = (salario − totalGasto) / salario.
+        - ONGOING: projected savings rate using historical average spend or run-rate, whichever is more reliable given the data — explain which you used.
+        Compare against the 50/30/20 rule (20% savings target) adapted for Eurozone households. Comment on financial resilience.
 
         # Alertas e Pontos de Atenção
-        Bullet list. Categories overspending, declining savings, groups consistently above target.
+        Bullet list. Calibrate to stage:
+        - CLOSED: actual overspending, declining savings, persistent target breaches across `historico`.
+        - ONGOING: run-rate red flags, categories on pace to break target, comparisons with the same point in prior months when relevant.
+        - EARLY-stage: do not raise alerts based on a few days of data — instead surface risks anchored in `historico` patterns.
 
         # Cenários de Investimento
-        Based on the current monthly surplus (or deficit), suggest 2-3 concrete Eurozone-context investment scenarios: e.g., MSCI World ETF (EUR-hedged), Portuguese/EU sovereign bonds, EUR high-yield savings accounts. For each: estimated annual return range and suitability given the observed savings pattern.
+        Based on the (projected, if ONGOING) monthly surplus, suggest 2-3 concrete Eurozone-context investment scenarios: e.g., MSCI World ETF (EUR-hedged), Portuguese/EU sovereign bonds, EUR high-yield savings accounts. For each: estimated annual return range and suitability given the observed (or projected) savings pattern.
 
         # Recomendações de Planejamento
-        5-7 concrete, actionable recommendations for next month. Be specific with € amounts where the data supports it.
+        5-7 concrete, actionable recommendations.
+        - CLOSED: focus on adjustments for the next month based on what happened.
+        - ONGOING: actionable items for the remainder of the current month + adjustments for next month. Be specific with € amounts where the data supports it.
 
         # Projeção para o Próximo Mês
-        Project total spend, savings rate, and which groups are most at risk of exceeding budget if behavior continues.
+        Project total spend, savings rate, and groups most at risk if behavior continues.
 
         Calculation rules:
-        - savings rate = (salary − totalGasto) / salary, expressed as a percentage with one decimal
+        - savings rate (CLOSED) = (salario − totalGasto) / salario, % with one decimal
+        - run-rate (ONGOING) = gasto / progresso (where progresso is fraction of month elapsed)
+        - projected savings rate (ONGOING) = (salario − run-rate total ou média histórica) / salario, % with one decimal — state the method used
         - € values: round to whole Euros unless precision is meaningful
-        - Cite specific numbers from the data (categories, percentages, deviations); never generalize without evidence in the snapshot
+        - Cite specific numbers from the data (categories, percentages, deviations); never generalize without evidence in the snapshot or `historico`
         """;
 
     public static string BuildUser(AnalysisInput input)
     {
         var json = JsonSerializer.Serialize(new
         {
+            dataAnalise = input.AnalysisDate.ToString("yyyy-MM-dd"),
             mesAtual = new
             {
                 referencia = input.CurrentMonth.ReferenceMonth,


### PR DESCRIPTION
## Summary
- `AnalysisInput` carries `AnalysisDate`; `AiAnalysisService` passes `DateTime.UtcNow`.
- Prompt builder serializes `dataAnalise` and the system prompt now classifies the stage (closed / early / mid / late / future) and adapts every section.
- Run-rate, projected savings rate and alert calibration covered in calculation rules.

## Test plan
- [x] dotnet build clean
- [x] dotnet test (13/13 passing, including AiAnalysisTests)
- [ ] Manual smoke: gerar relatório no início do mês e validar que as seções refletem o estágio "ONGOING / EARLY"

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)