### PR TITLE
fix: validate manual deploy workflow

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: Image tag to deploy (ex: main or sha-xxxxxxx)
+        description: "Image tag to deploy (ex: main or sha-xxxxxxx)"
         required: true
         default: main
 


### PR DESCRIPTION
Corrige o YAML inválido causado por dois-pontos em um scalar não citado. O workflow continua exclusivamente `workflow_dispatch`; nenhum gatilho automático de deploy foi adicionado.