### PR TITLE
Fix daily exchange-rate preload and latest-available fallback

### DIFF
--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -25,6 +25,7 @@ public sealed class InvestmentMarketDataService(
     TimeProvider timeProvider)
 {
     private static readonly SemaphoreSlim RefreshGate = new(1, 1);
+    private static readonly string[] BaselineFxCurrencies = ["BRL", "USD", "GBP", "GBX"];
     private readonly IReadOnlyList<IMarketQuoteProvider> _quoteProviders = quoteProviders.ToList();
     private readonly IReadOnlyList<IExchangeRateProvider> _exchangeRateProviders = exchangeRateProviders.ToList();
 
@@ -537,8 +538,8 @@ public sealed class InvestmentMarketDataService(
         List<ProviderFailure> failures,
         CancellationToken cancellationToken)
     {
-        var unresolved = instruments
-            .Select(item => item.NativeCurrency.Value)
+        var unresolved = BaselineFxCurrencies
+            .Concat(instruments.Select(item => item.NativeCurrency.Value))
             .Where(currency => currency != "EUR")
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/BcbPtaxExchangeRateProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/BcbPtaxExchangeRateProvider.cs
@@ -7,6 +7,8 @@ namespace CostTracker.Infrastructure.Investments.MarketData;
 
 public sealed class BcbPtaxExchangeRateProvider(HttpClient httpClient, TimeProvider timeProvider) : IExchangeRateProvider
 {
+    private static readonly DateOnly FirstAvailablePtaxDate = new(1984, 1, 1);
+
     public string ProviderCode => MarketDataProviderCodes.BcbPtax;
 
     public async Task<ProviderBatchResult<ExchangeRateResult>> GetLatestRatesAsync(
@@ -113,7 +115,7 @@ public sealed class BcbPtaxExchangeRateProvider(HttpClient httpClient, TimeProvi
         DateOnly asOf,
         CancellationToken cancellationToken)
     {
-        var initialDate = asOf.AddDays(-10).ToString("MM-dd-yyyy", CultureInfo.InvariantCulture);
+        var initialDate = FirstAvailablePtaxDate.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture);
         var finalDate = asOf.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture);
         var uri = "CotacaoMoedaPeriodo(moeda=@moeda,dataInicial=@dataInicial,dataFinalCotacao=@dataFinalCotacao)" +
                   $"?@moeda='{Uri.EscapeDataString(currency)}'" +

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/EcbExchangeRateProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/EcbExchangeRateProvider.cs
@@ -38,7 +38,7 @@ public sealed class EcbExchangeRateProvider(HttpClient httpClient, TimeProvider 
         {
             var currencyKey = string.Join('+', requested.Select(Uri.EscapeDataString));
             var uri = $"service/data/EXR/D.{currencyKey}.EUR.SP00.A" +
-                      $"?startPeriod={asOf.AddDays(-10):yyyy-MM-dd}&endPeriod={asOf:yyyy-MM-dd}" +
+                      $"?endPeriod={asOf:yyyy-MM-dd}" +
                       "&lastNObservations=1&format=csvdata";
             using var response = await httpClient.GetAsync(uri, cancellationToken);
             var payload = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -1,0 +1,76 @@
+using CostTracker.Application.Investments.MarketData;
+using CostTracker.Application.Options;
+using CostTracker.Application.Projections;
+using CostTracker.Application.Services;
+using CostTracker.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace CostTracker.Tests.Investments;
+
+public sealed class InvestmentMarketDataServiceTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 11, 6, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task Refresh_ShouldSeedEverySupportedFxCurrencyWithoutInstruments()
+    {
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"market-data-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var provider = new CapturingExchangeRateProvider(FixedNow);
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [],
+            [provider],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions { RefreshTimeZone = "Europe/Lisbon" }),
+            new FixedTimeProvider(FixedNow));
+
+        await service.RefreshAsync();
+        await service.RefreshAsync();
+
+        Assert.Equal(["BRL", "GBP", "USD"], provider.RequestedCurrencies.Order().ToArray());
+        Assert.Equal(1, provider.CallCount);
+        var rates = (await dbContext.FxRateSnapshots.ToListAsync())
+            .OrderBy(rate => rate.QuoteCurrency.Value)
+            .ToList();
+        Assert.Equal(["BRL", "GBP", "GBX", "USD"], rates.Select(rate => rate.QuoteCurrency.Value).ToArray());
+        Assert.Equal(125m, rates.Single(rate => rate.QuoteCurrency.Value == "GBX").Rate);
+    }
+
+    private sealed class CapturingExchangeRateProvider(DateTimeOffset fetchedAt) : IExchangeRateProvider
+    {
+        public string ProviderCode => "TEST_FX";
+        public IReadOnlyCollection<string> RequestedCurrencies { get; private set; } = [];
+        public int CallCount { get; private set; }
+
+        public Task<ProviderBatchResult<ExchangeRateResult>> GetLatestRatesAsync(
+            IReadOnlyCollection<string> quoteCurrencies,
+            DateOnly asOf,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            RequestedCurrencies = quoteCurrencies.ToArray();
+            IReadOnlyList<ExchangeRateResult> rates = quoteCurrencies
+                .Select(currency => new ExchangeRateResult(
+                    ProviderCode,
+                    "EUR",
+                    currency,
+                    currency == "GBP" ? 1.25m : 2m,
+                    "TEST",
+                    asOf,
+                    fetchedAt,
+                    false,
+                    new string('a', 64)))
+                .ToList();
+            return Task.FromResult(new ProviderBatchResult<ExchangeRateResult>(rates, []));
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
+++ b/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
@@ -91,6 +91,37 @@ public class MarketDataProvidersTests
     }
 
     [Fact]
+    public async Task Ecb_ShouldUseLatestObservationWithoutAnArbitraryLookbackWindow()
+    {
+        const string csv = """
+            KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE,OBS_STATUS
+            EXR.D.BRL.EUR.SP00.A,D,BRL,EUR,SP00,A,2025-12-31,6.4251,A
+            """;
+        Uri? requestedUri = null;
+        var provider = new EcbExchangeRateProvider(
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return TextResponse(csv);
+            }))
+            {
+                BaseAddress = new Uri("https://data-api.ecb.europa.eu/")
+            },
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestRatesAsync(
+            ["BRL"],
+            new DateOnly(2026, 8, 11),
+            CancellationToken.None);
+
+        var rate = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal(new DateOnly(2025, 12, 31), rate.AsOf);
+        Assert.DoesNotContain("startPeriod", requestedUri!.Query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("endPeriod=2026-08-11", requestedUri.Query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Bcb_ShouldDeriveEurBasedRatesFromClosingPtax()
     {
         const string eurPayload = """
@@ -122,6 +153,36 @@ public class MarketDataProvidersTests
             decimal.Round(5.88720m / 5.09630m, 10),
             decimal.Round(result.Items.Single(rate => rate.QuoteCurrency == "USD").Rate, 10));
         Assert.All(result.Items, rate => Assert.True(rate.IsFallback));
+    }
+
+    [Fact]
+    public async Task Bcb_ShouldUseLatestClosingPtaxFromAllAvailableHistory()
+    {
+        const string eurPayload = """
+            {"value":[{"cotacaoVenda":6.12340,"dataHoraCotacao":"2025-12-31 13:10:22.642754","tipoBoletim":"Fechamento"}]}
+            """;
+        Uri? requestedUri = null;
+        var provider = new BcbPtaxExchangeRateProvider(
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return JsonResponse(eurPayload);
+            }))
+            {
+                BaseAddress = new Uri("https://olinda.bcb.gov.br/olinda/servico/PTAX/versao/v1/odata/")
+            },
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestRatesAsync(
+            ["BRL"],
+            new DateOnly(2026, 8, 11),
+            CancellationToken.None);
+
+        var rate = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal(new DateOnly(2025, 12, 31), rate.AsOf);
+        Assert.Contains("01-01-1984", requestedUri!.Query, StringComparison.Ordinal);
+        Assert.Contains("08-11-2026", requestedUri.Query, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## O que mudou

- pré-carrega diariamente EUR/BRL, EUR/USD, EUR/GBP e EUR/GBX, mesmo antes de existir um ativo cadastrado
- mantém o bloqueio de uma coleta por moeda por dia
- consulta no BCE a última observação disponível até a data solicitada, sem janela artificial de 10 dias
- usa todo o histórico disponível da PTAX como fallback para encontrar o último fechamento anterior

## Causa raiz

O refresh inicial executava antes do primeiro ativo e derivava as moedas somente dos ativos existentes. Assim, nenhum câmbio era gravado e o próximo refresh aconteceria apenas no dia seguinte. Os providers também limitavam a procura aos 10 dias anteriores.

## Impacto

O cadastro e a valoração em BRL passam a ter câmbio disponível desde o startup. Em fins de semana, feriados ou lacunas de dados, o sistema usa a observação anterior mais recente. Se nunca houver observação, a conversão continua indisponível em vez de inventar uma taxa.

## Validação

- `dotnet test backend/CostTracker.sln --configuration Release --no-restore`: 61/61
- `dotnet ef migrations has-pending-model-changes ... --configuration Release --no-build`: sem mudanças de modelo
- `git diff --check`: limpo
- endpoint oficial do BCE e PTAX verificados com resposta HTTP 200