### PR TITLE
Refresh market quotes immediately after instrument registration

### DIFF
--- a/backend/CostTracker.Api/Program.cs
+++ b/backend/CostTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using CostTracker.Api.Configuration;
 using CostTracker.Api.Middleware;
 using CostTracker.Api.Services;
 using CostTracker.Application.Integrations.Ai;
+using CostTracker.Application.Investments.MarketData;
 using CostTracker.Application.Options;
 using CostTracker.Application.Pdf;
 using CostTracker.Application.Projections;
@@ -92,6 +93,9 @@ builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddInvestmentMarketData(builder.Configuration);
 builder.Services.AddScoped<PortfolioProjectionService>();
+builder.Services.AddSingleton<InvestmentMarketDataRefreshSignal>();
+builder.Services.AddSingleton<IMarketDataRefreshScheduler>(provider =>
+    provider.GetRequiredService<InvestmentMarketDataRefreshSignal>());
 builder.Services.AddScoped<PortfolioManagementService>();
 builder.Services.AddScoped<InvestmentMarketDataService>();
 builder.Services.AddScoped<ContributionPlanningService>();

--- a/backend/CostTracker.Api/Services/InvestmentMarketDataRefreshSignal.cs
+++ b/backend/CostTracker.Api/Services/InvestmentMarketDataRefreshSignal.cs
@@ -1,0 +1,25 @@
+using System.Threading.Channels;
+using CostTracker.Application.Investments.MarketData;
+
+namespace CostTracker.Api.Services;
+
+public sealed class InvestmentMarketDataRefreshSignal : IMarketDataRefreshScheduler
+{
+    private readonly Channel<bool> _requests = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
+    {
+        SingleReader = true,
+        SingleWriter = false,
+        FullMode = BoundedChannelFullMode.DropWrite
+    });
+
+    public void RequestRefresh() => _requests.Writer.TryWrite(true);
+
+    public async ValueTask WaitAsync(CancellationToken cancellationToken)
+    {
+        _ = await _requests.Reader.ReadAsync(cancellationToken);
+        while (_requests.Reader.TryRead(out _))
+        {
+            // Coalesce bursts of portfolio mutations into one provider refresh.
+        }
+    }
+}

--- a/backend/CostTracker.Api/Services/InvestmentMarketDataRefreshWorker.cs
+++ b/backend/CostTracker.Api/Services/InvestmentMarketDataRefreshWorker.cs
@@ -8,6 +8,7 @@ public sealed class InvestmentMarketDataRefreshWorker(
     IServiceScopeFactory scopeFactory,
     IOptions<MarketDataOptions> options,
     TimeProvider timeProvider,
+    InvestmentMarketDataRefreshSignal refreshSignal,
     ILogger<InvestmentMarketDataRefreshWorker> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -25,7 +26,32 @@ public sealed class InvestmentMarketDataRefreshWorker(
         {
             var delay = DelayUntilNextRefresh();
             logger.LogInformation("Next investment market-data refresh in {Delay}.", delay);
-            await Task.Delay(delay, timeProvider, stoppingToken);
+            using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            var scheduledRefresh = Task.Delay(delay, timeProvider, waitCancellation.Token);
+            var requestedRefresh = refreshSignal.WaitAsync(waitCancellation.Token).AsTask();
+            var completed = await Task.WhenAny(scheduledRefresh, requestedRefresh);
+            var triggeredByPortfolioChange = completed == requestedRefresh;
+            waitCancellation.Cancel();
+
+            try
+            {
+                await Task.WhenAll(scheduledRefresh, requestedRefresh);
+            }
+            catch (OperationCanceledException) when (!stoppingToken.IsCancellationRequested)
+            {
+                // The losing wait is cancelled after either the schedule or signal wins.
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+                break;
+
+            if (triggeredByPortfolioChange)
+                logger.LogInformation("Investment market-data refresh requested after a portfolio change.");
+
             await RefreshSafelyAsync(stoppingToken);
         }
     }

--- a/backend/CostTracker.Application/Investments/MarketData/IMarketDataRefreshScheduler.cs
+++ b/backend/CostTracker.Application/Investments/MarketData/IMarketDataRefreshScheduler.cs
@@ -1,0 +1,6 @@
+namespace CostTracker.Application.Investments.MarketData;
+
+public interface IMarketDataRefreshScheduler
+{
+    void RequestRefresh();
+}

--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -477,7 +477,10 @@ public sealed class InvestmentMarketDataService(
                 // being labelled as GBP and overstating the position by 100x.
                 if (provider.ProviderCode == MarketDataProviderCodes.Marketstack && explicitMapping is null)
                     continue;
-                var symbol = explicitMapping?.ProviderSymbol ?? instrument.Ticker;
+                var symbol = explicitMapping?.ProviderSymbol ?? ResolveProviderSymbol(
+                    provider.ProviderCode,
+                    instrument.Ticker,
+                    instrument.Mic);
                 if (string.IsNullOrWhiteSpace(symbol))
                     continue;
 
@@ -530,6 +533,22 @@ public sealed class InvestmentMarketDataService(
             instrument.Ticker ?? instrument.Name,
             "No configured provider returned a quote for this instrument.",
             false)));
+    }
+
+    private static string? ResolveProviderSymbol(string providerCode, string? ticker, string? mic)
+    {
+        if (string.IsNullOrWhiteSpace(ticker) ||
+            !string.Equals(providerCode, MarketDataProviderCodes.YahooTest, StringComparison.OrdinalIgnoreCase) ||
+            ticker.Contains('.', StringComparison.Ordinal))
+        {
+            return ticker;
+        }
+
+        return mic?.Trim().ToUpperInvariant() switch
+        {
+            "XLON" or "LSE" => $"{ticker}.L",
+            _ => ticker
+        };
     }
 
     private async Task RefreshExchangeRatesAsync(

--- a/backend/CostTracker.Application/Services/PortfolioManagementService.cs
+++ b/backend/CostTracker.Application/Services/PortfolioManagementService.cs
@@ -1,6 +1,7 @@
 using CostTracker.Application.Contracts;
 using CostTracker.Application.Exceptions;
 using CostTracker.Application.Interfaces;
+using CostTracker.Application.Investments.MarketData;
 using CostTracker.Application.Options;
 using CostTracker.Application.Projections;
 using CostTracker.Domain.Entities;
@@ -15,7 +16,8 @@ public class PortfolioManagementService(
     ICostTrackerDbContext dbContext,
     PortfolioProjectionService projectionService,
     TimeProvider timeProvider,
-    IOptions<MarketDataOptions> marketDataOptions)
+    IOptions<MarketDataOptions> marketDataOptions,
+    IMarketDataRefreshScheduler marketDataRefreshScheduler)
 {
     public async Task<InvestmentPortfolioDto> GetPortfolioAsync(CancellationToken cancellationToken)
     {
@@ -140,6 +142,7 @@ public class PortfolioManagementService(
         portfolio.Touch(now);
 
         await SaveChangesAsync(cancellationToken);
+        RequestMarketDataRefreshIfNeeded(instrument);
         return projectionService.ToInstrumentDetailDto(instrument);
     }
 
@@ -191,6 +194,7 @@ public class PortfolioManagementService(
         instrument.Portfolio.Touch(now);
 
         await SaveChangesAsync(cancellationToken);
+        RequestMarketDataRefreshIfNeeded(instrument);
         return projectionService.ToInstrumentDetailDto(instrument);
     }
 
@@ -254,6 +258,7 @@ public class PortfolioManagementService(
         instrument.Portfolio.Touch(now);
 
         await SaveChangesAsync(cancellationToken);
+        RequestMarketDataRefreshIfNeeded(instrument);
         return projectionService.ToInstrumentDetailDto(instrument);
     }
 
@@ -313,6 +318,15 @@ public class PortfolioManagementService(
         await dbContext.InvestmentPortfolios.AddAsync(portfolio, cancellationToken);
         await SaveChangesAsync(cancellationToken);
         return portfolio;
+    }
+
+    private void RequestMarketDataRefreshIfNeeded(InvestmentInstrument instrument)
+    {
+        if (instrument.ValuationMode == ValuationMode.MarketQuote &&
+            !string.IsNullOrWhiteSpace(instrument.Ticker))
+        {
+            marketDataRefreshScheduler.RequestRefresh();
+        }
     }
 
     private async Task<InvestmentInstrument> LoadInstrumentAsync(

--- a/backend/CostTracker.Tests/Integration/InvestmentsApiTests.cs
+++ b/backend/CostTracker.Tests/Integration/InvestmentsApiTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using CostTracker.Api.Services;
 using CostTracker.Application.Contracts;
 using CostTracker.Application.Investments.MarketData;
 using CostTracker.Application.Options;
@@ -14,6 +15,32 @@ namespace CostTracker.Tests.Integration;
 
 public class InvestmentsApiTests
 {
+    [Fact]
+    public async Task MarketInstrumentRegistration_ShouldRequestImmediateMarketDataRefresh()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await LoginAndConfigureAsync(client);
+        var signal = factory.Services.GetRequiredService<InvestmentMarketDataRefreshSignal>();
+
+        var response = await client.PostAsJsonAsync("/api/investments/instruments", new CreateInvestmentInstrumentRequest
+        {
+            AssetClass = "REITS",
+            Kind = "REIT",
+            Name = "Realty Income",
+            Ticker = "O",
+            Mic = "XNYS",
+            NativeCurrency = "USD",
+            ValuationMode = "MARKET_QUOTE",
+            AllocationScore = 10,
+            QuantityStep = 0.000001m
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        await signal.WaitAsync(timeout.Token);
+    }
+
     [Fact]
     public async Task Allocation_ShouldRequireAllFiveClassesAndWholePercentagesAndPersistAtomically()
     {

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataRefreshWorkerTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataRefreshWorkerTests.cs
@@ -1,0 +1,88 @@
+using CostTracker.Api.Services;
+using CostTracker.Application.Interfaces;
+using CostTracker.Application.Investments.MarketData;
+using CostTracker.Application.Options;
+using CostTracker.Application.Projections;
+using CostTracker.Application.Services;
+using CostTracker.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace CostTracker.Tests.Investments;
+
+public sealed class InvestmentMarketDataRefreshWorkerTests
+{
+    [Fact]
+    public async Task PortfolioChangeSignal_ShouldRefreshWithoutWaitingForDailySchedule()
+    {
+        var now = new DateTimeOffset(2026, 8, 11, 12, 0, 0, TimeSpan.Zero);
+        var timeProvider = new FixedTimeProvider(now);
+        var marketDataOptions = Options.Create(new MarketDataOptions
+        {
+            EnableBackgroundRefresh = true,
+            RefreshOnStartup = false,
+            RefreshTimeZone = "Europe/Lisbon",
+            RefreshHour = 6
+        });
+        var provider = new NotifyingExchangeRateProvider(now);
+        var services = new ServiceCollection();
+        services.AddDbContext<CostTrackerDbContext>(options =>
+            options.UseInMemoryDatabase($"refresh-worker-{Guid.NewGuid():N}"));
+        services.AddScoped<ICostTrackerDbContext>(serviceProvider =>
+            serviceProvider.GetRequiredService<CostTrackerDbContext>());
+        services.AddScoped<PortfolioProjectionService>();
+        services.AddScoped<InvestmentMarketDataService>();
+        services.AddSingleton<IExchangeRateProvider>(provider);
+        services.AddSingleton<IOptions<MarketDataOptions>>(marketDataOptions);
+        services.AddSingleton<TimeProvider>(timeProvider);
+        await using var serviceProvider = services.BuildServiceProvider();
+        var signal = new InvestmentMarketDataRefreshSignal();
+        var worker = new InvestmentMarketDataRefreshWorker(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            marketDataOptions,
+            timeProvider,
+            signal,
+            NullLogger<InvestmentMarketDataRefreshWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+        signal.RequestRefresh();
+        await provider.Called.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.Equal(1, provider.CallCount);
+    }
+
+    private sealed class NotifyingExchangeRateProvider(DateTimeOffset fetchedAt) : IExchangeRateProvider
+    {
+        public string ProviderCode => "TEST_FX";
+        public int CallCount { get; private set; }
+        public TaskCompletionSource Called { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<ProviderBatchResult<ExchangeRateResult>> GetLatestRatesAsync(
+            IReadOnlyCollection<string> quoteCurrencies,
+            DateOnly asOf,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            Called.TrySetResult();
+            IReadOnlyList<ExchangeRateResult> rates = quoteCurrencies.Select(currency => new ExchangeRateResult(
+                ProviderCode,
+                "EUR",
+                currency,
+                1m,
+                "TEST",
+                asOf,
+                fetchedAt,
+                false,
+                new string('c', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<ExchangeRateResult>(rates, []));
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -2,6 +2,9 @@ using CostTracker.Application.Investments.MarketData;
 using CostTracker.Application.Options;
 using CostTracker.Application.Projections;
 using CostTracker.Application.Services;
+using CostTracker.Domain.Entities;
+using CostTracker.Domain.Enums;
+using CostTracker.Domain.ValueObjects;
 using CostTracker.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -38,6 +41,87 @@ public sealed class InvestmentMarketDataServiceTests
             .ToList();
         Assert.Equal(["BRL", "GBP", "GBX", "USD"], rates.Select(rate => rate.QuoteCurrency.Value).ToArray());
         Assert.Equal(125m, rates.Single(rate => rate.QuoteCurrency.Value == "GBX").Rate);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldResolveProviderSymbolFromExchangeMic()
+    {
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"market-symbols-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var portfolio = InvestmentPortfolio.Create(FixedNow);
+        portfolio.Instruments.Add(CreateQuotedInstrument(portfolio, "VWRA", "XLON"));
+        portfolio.Instruments.Add(CreateQuotedInstrument(portfolio, "O", "XNYS"));
+        dbContext.InvestmentPortfolios.Add(portfolio);
+        await dbContext.SaveChangesAsync();
+
+        var quoteProvider = new CapturingQuoteProvider(FixedNow);
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [quoteProvider],
+            [new CapturingExchangeRateProvider(FixedNow)],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions
+            {
+                RefreshTimeZone = "Europe/Lisbon",
+                EnablePublicTestQuotes = true
+            }),
+            new FixedTimeProvider(FixedNow));
+
+        await service.RefreshAsync();
+
+        Assert.Equal(["O", "VWRA.L"], quoteProvider.Requests.Select(request => request.ProviderSymbol).Order().ToArray());
+    }
+
+    private static InvestmentInstrument CreateQuotedInstrument(
+        InvestmentPortfolio portfolio,
+        string ticker,
+        string mic)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            PortfolioId = portfolio.Id,
+            Portfolio = portfolio,
+            AssetClass = ticker == "O" ? AssetClass.Reits : AssetClass.Stocks,
+            Kind = ticker == "O" ? InstrumentKind.Reit : InstrumentKind.Etf,
+            Name = ticker,
+            Ticker = ticker,
+            Mic = mic,
+            IdentityKey = $"TICKER:{mic}:{ticker}",
+            NativeCurrency = new CurrencyCode("USD"),
+            ValuationMode = ValuationMode.MarketQuote,
+            AllocationScore = 10,
+            QuantityStep = 0.000001m,
+            CreatedAt = FixedNow,
+            UpdatedAt = FixedNow
+        };
+
+    private sealed class CapturingQuoteProvider(DateTimeOffset fetchedAt) : IMarketQuoteProvider
+    {
+        public string ProviderCode => MarketDataProviderCodes.YahooTest;
+        public IReadOnlyList<MarketQuoteRequest> Requests { get; private set; } = [];
+
+        public Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+            IReadOnlyList<MarketQuoteRequest> requests,
+            CancellationToken cancellationToken)
+        {
+            Requests = requests;
+            IReadOnlyList<MarketQuoteResult> quotes = requests.Select(request => new MarketQuoteResult(
+                request.InstrumentId,
+                ProviderCode,
+                request.ProviderSymbol,
+                request.Exchange,
+                request.Mic,
+                100m,
+                request.ExpectedCurrency,
+                "LATEST_AVAILABLE",
+                DateOnly.FromDateTime(fetchedAt.Date),
+                fetchedAt,
+                true,
+                new string('b', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<MarketQuoteResult>(quotes, []));
+        }
     }
 
     private sealed class CapturingExchangeRateProvider(DateTimeOffset fetchedAt) : IExchangeRateProvider

--- a/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { z } from 'zod';
@@ -55,7 +56,19 @@ export function InstrumentDetailPage() {
   const { instrumentId = '' } = useParams();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const instrumentsQuery = useQuery({ queryKey: investmentQueryKeys.instruments(), queryFn: investmentsApi.getInstruments });
+  const [quotePollingDeadline] = useState(() => Date.now() + 20_000);
+  const instrumentsQuery = useQuery({
+    queryKey: investmentQueryKeys.instruments(),
+    queryFn: investmentsApi.getInstruments,
+    refetchInterval: (query) => {
+      const current = query.state.data?.find((item) => item.instrumentId === instrumentId);
+      return Date.now() < quotePollingDeadline &&
+        current?.valuationMode === 'MARKET_QUOTE' &&
+        !current.marketData
+        ? 1_000
+        : false;
+    }
+  });
   const transactionsQuery = useQuery({
     queryKey: investmentQueryKeys.transactions(instrumentId),
     queryFn: () => investmentsApi.getTransactions(instrumentId),


### PR DESCRIPTION
## O que mudou

- dispara o worker de market data imediatamente após cadastrar, editar ou movimentar um instrumento com ticker
- mantém o refresh diário das 06:00 como proteção e coalesce várias alterações próximas em uma única execução
- resolve automaticamente tickers da London Stock Exchange para o fallback público (`VWRA` + `XLON` → `VWRA.L`)
- mantém tickers de Nova York sem sufixo (`O` + `XNYS` → `O`)
- a tela do instrumento acompanha por até 20 segundos a chegada da primeira cotação, sem exigir reload manual

## Causa raiz

O worker só aguardava o próximo horário diário. Instrumentos criados depois do startup permaneciam sem cotação até o dia seguinte. Além disso, o fallback público precisa do sufixo `.L` para símbolos negociados em Londres quando não há mapping explícito.

## Validação

- reprodução em produção: `O` e `VWRA.L` criados após o último refresh tinham zero snapshots
- refresh de controle confirmou `O = US$ 62,07` e `VWRA.L = US$ 194,42`
- `dotnet test backend/CostTracker.sln --configuration Release --no-restore`: 64/64
- `npm test -- --run`: 26/26
- `npm run build`: sucesso
- EF Core: nenhuma mudança de modelo/migração
- `git diff --check`: limpo