### PR TITLE
Replace native archive confirmation with application modal

### DIFF
--- a/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
@@ -13,6 +13,7 @@ import type { CurrencyCode, TransactionType } from '../types';
 import { createIdempotencyKey, todayIso } from '../utils';
 import { formatDateIsoToPt } from '../../../utils/format';
 import { PrivacyMask } from '../../../contexts/PrivacyContext';
+import { ConfirmModal } from '../../../components/ConfirmModal';
 
 const transactionSchema = z.object({
   type: z.enum(['BUY', 'SELL', 'DEPOSIT', 'WITHDRAWAL', 'ADJUSTMENT']),
@@ -56,6 +57,7 @@ export function InstrumentDetailPage() {
   const { instrumentId = '' } = useParams();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [archiveConfirmationOpen, setArchiveConfirmationOpen] = useState(false);
   const [quotePollingDeadline] = useState(() => Date.now() + 20_000);
   const instrumentsQuery = useQuery({
     queryKey: investmentQueryKeys.instruments(),
@@ -138,6 +140,7 @@ export function InstrumentDetailPage() {
   const archiveMutation = useMutation({
     mutationFn: () => investmentsApi.archiveInstrument(instrumentId, instrument?.version),
     onSuccess: async () => {
+      setArchiveConfirmationOpen(false);
       await queryClient.invalidateQueries({ queryKey: investmentQueryKeys.all });
       navigate('/investimentos');
     }
@@ -164,9 +167,7 @@ export function InstrumentDetailPage() {
           </div>
           <div className="investment-header-actions">
             <Link className="investment-secondary-link" to={`/investimentos/ativos/${instrumentId}/editar`}>Editar</Link>
-            <button className="button-danger" type="button" disabled={archiveMutation.isPending} onClick={() => {
-              if (window.confirm('Arquivar este ativo? O histórico será preservado.')) archiveMutation.mutate();
-            }}>Arquivar</button>
+            <button className="button-danger" type="button" disabled={archiveMutation.isPending} onClick={() => setArchiveConfirmationOpen(true)}>Arquivar</button>
           </div>
         </header>
         <dl className="instrument-detail-kpis">
@@ -214,7 +215,7 @@ export function InstrumentDetailPage() {
               </details>
             </>
           )}
-          {(transactionMutation.isError || valuationMutation.isError || quoteMutation.isError) && <p className="investment-alert" data-tone="danger" role="alert">{investmentErrorMessage(transactionMutation.error ?? valuationMutation.error ?? quoteMutation.error)}</p>}
+          {(transactionMutation.isError || valuationMutation.isError || quoteMutation.isError || archiveMutation.isError) && <p className="investment-alert" data-tone="danger" role="alert">{investmentErrorMessage(transactionMutation.error ?? valuationMutation.error ?? quoteMutation.error ?? archiveMutation.error)}</p>}
         </section>
 
         <section className="investment-panel">
@@ -240,6 +241,18 @@ export function InstrumentDetailPage() {
           {(transactionsQuery.data?.length ?? 0) === 0 && (valuationsQuery.data?.length ?? 0) === 0 && !transactionsQuery.isLoading && <p className="investment-empty-copy">Ainda não há eventos registrados.</p>}
         </section>
       </div>
+      <ConfirmModal
+        open={archiveConfirmationOpen}
+        title="Arquivar ativo?"
+        description="O ativo deixará de aparecer na carteira, mas todo o histórico será preservado."
+        confirmLabel={archiveMutation.isPending ? 'A arquivar…' : 'Arquivar'}
+        onConfirm={() => {
+          if (!archiveMutation.isPending) archiveMutation.mutate();
+        }}
+        onCancel={() => {
+          if (!archiveMutation.isPending) setArchiveConfirmationOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/no-native-dialogs.test.ts
+++ b/frontend/src/no-native-dialogs.test.ts
@@ -1,0 +1,24 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.(ts|tsx)$/.test(entry) && !entry.endsWith('.test.ts') && !entry.endsWith('.test.tsx')
+      ? [path]
+      : [];
+  });
+}
+
+describe('frontend dialogs', () => {
+  it('uses application modals instead of native browser dialogs', () => {
+    const violations = sourceFiles(join(process.cwd(), 'src')).flatMap((path) => {
+      const source = readFileSync(path, 'utf8');
+      return /\b(?:window\.)?(?:alert|confirm|prompt)\s*\(/.test(source) ? [path] : [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## O que mudou

- substitui o `window.confirm` usado ao arquivar um investimento pelo `ConfirmModal` visual do sistema
- preserva o histórico e mantém o modal aberto enquanto o arquivamento está em andamento
- mostra erros do arquivamento dentro da página
- adiciona uma regressão global que falha se `alert`, `confirm` ou `prompt` nativos forem reintroduzidos no frontend

## Causa raiz

A tela de detalhes do investimento implementou a confirmação diretamente com a API nativa do navegador, sem reutilizar o componente de modal já usado no restante do produto.

## Validação

- busca completa no frontend: nenhuma chamada nativa restante
- `npm test -- --run`: 27/27
- `npm run build`: sucesso
- `git diff --check`: limpo