### PR TITLE
Retry stale market data on manual refresh

### DIFF
--- a/backend/CostTracker.Api/Controllers/InvestmentMarketDataController.cs
+++ b/backend/CostTracker.Api/Controllers/InvestmentMarketDataController.cs
@@ -14,7 +14,7 @@ public sealed class InvestmentMarketDataController(InvestmentMarketDataService s
 
     [HttpPost("refresh")]
     public async Task<ActionResult<MarketDataStatusDto>> Refresh(CancellationToken cancellationToken)
-        => Ok(await service.RefreshAsync(cancellationToken));
+        => Ok(await service.RefreshAsync(cancellationToken, retryStaleSources: true));
 
     [HttpGet("instruments/{instrumentId:guid}/mappings")]
     public async Task<ActionResult<IReadOnlyList<MarketInstrumentMappingDto>>> GetMappings(

--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -32,7 +32,9 @@ public sealed class InvestmentMarketDataService(
     public async Task<MarketDataStatusDto> GetStatusAsync(CancellationToken cancellationToken = default)
         => await BuildStatusAsync([], cancellationToken);
 
-    public async Task<MarketDataStatusDto> RefreshAsync(CancellationToken cancellationToken = default)
+    public async Task<MarketDataStatusDto> RefreshAsync(
+        CancellationToken cancellationToken = default,
+        bool retryStaleSources = false)
     {
         await RefreshGate.WaitAsync(cancellationToken);
         try
@@ -50,12 +52,18 @@ public sealed class InvestmentMarketDataService(
                 .Where(instrument => RequiresMarketData(instrument))
                 .ToList();
 
-            await RefreshExchangeRatesAsync(instrumentsRequiringValuation, today, failures, cancellationToken);
+            await RefreshExchangeRatesAsync(
+                instrumentsRequiringValuation,
+                today,
+                retryStaleSources,
+                failures,
+                cancellationToken);
             await RefreshQuotesAsync(
                 instrumentsRequiringValuation
                     .Where(item => item.ValuationMode == ValuationMode.MarketQuote)
                     .ToList(),
                 today,
+                retryStaleSources,
                 failures,
                 cancellationToken);
 
@@ -433,6 +441,7 @@ public sealed class InvestmentMarketDataService(
     private async Task RefreshQuotesAsync(
         IReadOnlyList<InvestmentInstrument> instruments,
         DateOnly today,
+        bool retryStaleSources,
         List<ProviderFailure> failures,
         CancellationToken cancellationToken)
     {
@@ -444,14 +453,22 @@ public sealed class InvestmentMarketDataService(
             .Where(item => instrumentIds.Contains(item.InstrumentId))
             .AsNoTracking()
             .ToListAsync(cancellationToken);
-        var latestFetches = await dbContext.MarketQuoteSnapshots
+        var snapshotMetadata = await dbContext.MarketQuoteSnapshots
             .Where(item => instrumentIds.Contains(item.InstrumentId))
-            .GroupBy(item => item.InstrumentId)
-            .Select(group => new { InstrumentId = group.Key, FetchedAt = group.Max(item => item.FetchedAt) })
+            .Select(item => new { item.InstrumentId, item.AsOf, item.FetchedAt })
+            .AsNoTracking()
             .ToListAsync(cancellationToken);
-        var refreshedToday = latestFetches
-            .Where(item => LocalDate(item.FetchedAt) == today)
-            .Select(item => item.InstrumentId)
+        var refreshedToday = snapshotMetadata
+            .GroupBy(item => item.InstrumentId)
+            .Where(group => LocalDate(group.Max(item => item.FetchedAt)) == today)
+            .Where(group => !retryStaleSources ||
+                            ClassifyQuote(
+                                group.OrderByDescending(item => item.AsOf)
+                                    .ThenByDescending(item => item.FetchedAt)
+                                    .First()
+                                    .AsOf,
+                                today) == DataFreshnessCodes.Fresh)
+            .Select(group => group.Key)
             .ToHashSet();
         var unresolved = instruments
             .Where(item => !refreshedToday.Contains(item.Id))
@@ -554,6 +571,7 @@ public sealed class InvestmentMarketDataService(
     private async Task RefreshExchangeRatesAsync(
         IReadOnlyList<InvestmentInstrument> instruments,
         DateOnly today,
+        bool retryStaleSources,
         List<ProviderFailure> failures,
         CancellationToken cancellationToken)
     {
@@ -565,13 +583,23 @@ public sealed class InvestmentMarketDataService(
         if (unresolved.Count > 0)
         {
             var currencies = unresolved.Select(value => new CurrencyCode(value)).ToList();
-            var latestFetches = await dbContext.FxRateSnapshots
+            var snapshotMetadata = await dbContext.FxRateSnapshots
                 .Where(item => item.BaseCurrency == CurrencyCode.Eur && currencies.Contains(item.QuoteCurrency))
-                .GroupBy(item => item.QuoteCurrency)
-                .Select(group => new { QuoteCurrency = group.Key, FetchedAt = group.Max(item => item.FetchedAt) })
+                .Select(item => new { item.QuoteCurrency, item.AsOf, item.FetchedAt })
+                .AsNoTracking()
                 .ToListAsync(cancellationToken);
-            foreach (var recent in latestFetches.Where(item => LocalDate(item.FetchedAt) == today))
-                unresolved.Remove(recent.QuoteCurrency.Value);
+            foreach (var group in snapshotMetadata.GroupBy(item => item.QuoteCurrency))
+            {
+                if (LocalDate(group.Max(item => item.FetchedAt)) != today)
+                    continue;
+
+                var current = group
+                    .OrderByDescending(item => item.AsOf)
+                    .ThenByDescending(item => item.FetchedAt)
+                    .First();
+                if (!retryStaleSources || ClassifyQuote(current.AsOf, today) == DataFreshnessCodes.Fresh)
+                    unresolved.Remove(group.Key.Value);
+            }
         }
 
         foreach (var provider in _exchangeRateProviders)

--- a/backend/CostTracker.Tests/Integration/InvestmentsApiTests.cs
+++ b/backend/CostTracker.Tests/Integration/InvestmentsApiTests.cs
@@ -7,14 +7,66 @@ using CostTracker.Application.Options;
 using CostTracker.Domain.Entities;
 using CostTracker.Domain.ValueObjects;
 using CostTracker.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace CostTracker.Tests.Integration;
 
 public class InvestmentsApiTests
 {
+    [Fact]
+    public async Task ManualMarketDataRefresh_ShouldRetryAStaleQuoteFetchedEarlierTheSameDay()
+    {
+        var now = new DateTimeOffset(2026, 8, 18, 6, 44, 0, TimeSpan.Zero);
+        var quoteProvider = new SequencedHttpQuoteProvider(
+            now,
+            new DateOnly(2026, 8, 14),
+            new DateOnly(2026, 8, 17));
+        using var baseFactory = new TestWebApplicationFactory();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<TimeProvider>();
+                services.AddSingleton<TimeProvider>(new FixedTimeProvider(now));
+                services.RemoveAll<IMarketQuoteProvider>();
+                services.AddSingleton<IMarketQuoteProvider>(quoteProvider);
+                services.RemoveAll<IExchangeRateProvider>();
+                services.AddSingleton<IExchangeRateProvider>(new FixedExchangeRateProvider(now));
+            }));
+        using var client = factory.CreateClient();
+        await LoginAndConfigureAsync(client);
+
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/investments/instruments",
+            new CreateInvestmentInstrumentRequest
+            {
+                AssetClass = "STOCKS",
+                Kind = "STOCK",
+                Name = "Bank of America",
+                Ticker = "BAC",
+                Mic = "XNYS",
+                NativeCurrency = "USD",
+                ValuationMode = "MARKET_QUOTE",
+                AllocationScore = 10,
+                QuantityStep = 0.000001m
+            });
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var firstResponse = await client.PostAsync("/api/investments/market-data/refresh", null);
+        var first = await firstResponse.Content.ReadFromJsonAsync<MarketDataStatusDto>();
+        var retryResponse = await client.PostAsync("/api/investments/market-data/refresh", null);
+        var retried = await retryResponse.Content.ReadFromJsonAsync<MarketDataStatusDto>();
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal(DataFreshnessCodes.Stale, first!.Freshness);
+        Assert.Equal(HttpStatusCode.OK, retryResponse.StatusCode);
+        Assert.Equal(2, quoteProvider.CallCount);
+        Assert.Equal(DataFreshnessCodes.Fresh, retried!.Freshness);
+    }
+
     [Fact]
     public async Task MarketInstrumentRegistration_ShouldRequestImmediateMarketDataRefresh()
     {
@@ -766,5 +818,63 @@ public class InvestmentsApiTests
             Password = TestWebApplicationFactory.TestPassword
         });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private sealed class SequencedHttpQuoteProvider(
+        DateTimeOffset fetchedAt,
+        params DateOnly[] dates) : IMarketQuoteProvider
+    {
+        public string ProviderCode => "TEST_QUOTES";
+        public int CallCount { get; private set; }
+
+        public Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+            IReadOnlyList<MarketQuoteRequest> requests,
+            CancellationToken cancellationToken)
+        {
+            var asOf = dates[Math.Min(CallCount, dates.Length - 1)];
+            CallCount++;
+            IReadOnlyList<MarketQuoteResult> quotes = requests.Select(request => new MarketQuoteResult(
+                request.InstrumentId,
+                ProviderCode,
+                request.ProviderSymbol,
+                request.Exchange,
+                request.Mic,
+                100m,
+                request.ExpectedCurrency,
+                "LATEST_AVAILABLE",
+                asOf,
+                fetchedAt,
+                false,
+                new string('e', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<MarketQuoteResult>(quotes, []));
+        }
+    }
+
+    private sealed class FixedExchangeRateProvider(DateTimeOffset fetchedAt) : IExchangeRateProvider
+    {
+        public string ProviderCode => "TEST_FX";
+
+        public Task<ProviderBatchResult<ExchangeRateResult>> GetLatestRatesAsync(
+            IReadOnlyCollection<string> quoteCurrencies,
+            DateOnly asOf,
+            CancellationToken cancellationToken)
+        {
+            IReadOnlyList<ExchangeRateResult> rates = quoteCurrencies.Select(currency => new ExchangeRateResult(
+                ProviderCode,
+                "EUR",
+                currency,
+                2m,
+                "TEST",
+                asOf,
+                fetchedAt,
+                false,
+                new string('f', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<ExchangeRateResult>(rates, []));
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
     }
 }

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -74,6 +74,78 @@ public sealed class InvestmentMarketDataServiceTests
         Assert.Equal(["O", "VWRA.L"], quoteProvider.Requests.Select(request => request.ProviderSymbol).Order().ToArray());
     }
 
+    [Fact]
+    public async Task Refresh_ShouldRetryAStaleQuoteOnlyWhenRequestedLaterOnTheSameDay()
+    {
+        var now = new DateTimeOffset(2026, 8, 18, 6, 44, 0, TimeSpan.Zero);
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"market-stale-retry-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var portfolio = InvestmentPortfolio.Create(now);
+        portfolio.Instruments.Add(CreateQuotedInstrument(portfolio, "BAC", "XNYS"));
+        dbContext.InvestmentPortfolios.Add(portfolio);
+        await dbContext.SaveChangesAsync();
+
+        var quoteProvider = new SequencedQuoteProvider(
+            now,
+            new DateOnly(2026, 8, 14),
+            new DateOnly(2026, 8, 17));
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [quoteProvider],
+            [new CapturingExchangeRateProvider(now)],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions
+            {
+                RefreshTimeZone = "Europe/Lisbon",
+                EnablePublicTestQuotes = true
+            }),
+            new FixedTimeProvider(now));
+
+        var first = await service.RefreshAsync();
+        var deduplicated = await service.RefreshAsync();
+        var retried = await service.RefreshAsync(retryStaleSources: true);
+
+        Assert.Equal(DataFreshnessCodes.Stale, first.Freshness);
+        Assert.Equal(DataFreshnessCodes.Stale, deduplicated.Freshness);
+        Assert.Equal(2, quoteProvider.CallCount);
+        Assert.Equal(DataFreshnessCodes.Fresh, retried.Freshness);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldRetryStaleExchangeRatesOnlyWhenRequestedLaterOnTheSameDay()
+    {
+        var now = new DateTimeOffset(2026, 8, 18, 6, 44, 0, TimeSpan.Zero);
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"fx-stale-retry-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var exchangeRateProvider = new SequencedExchangeRateProvider(
+            now,
+            new DateOnly(2026, 8, 14),
+            new DateOnly(2026, 8, 17));
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [],
+            [exchangeRateProvider],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions { RefreshTimeZone = "Europe/Lisbon" }),
+            new FixedTimeProvider(now));
+
+        await service.RefreshAsync();
+        await service.RefreshAsync();
+        await service.RefreshAsync(retryStaleSources: true);
+
+        Assert.Equal(2, exchangeRateProvider.CallCount);
+        Assert.All(
+            await dbContext.FxRateSnapshots
+                .GroupBy(rate => rate.QuoteCurrency)
+                .Select(group => group.Max(rate => rate.AsOf))
+                .ToListAsync(),
+            asOf => Assert.Equal(new DateOnly(2026, 8, 17), asOf));
+    }
+
     private static InvestmentInstrument CreateQuotedInstrument(
         InvestmentPortfolio portfolio,
         string ticker,
@@ -124,6 +196,36 @@ public sealed class InvestmentMarketDataServiceTests
         }
     }
 
+    private sealed class SequencedQuoteProvider(
+        DateTimeOffset fetchedAt,
+        params DateOnly[] dates) : IMarketQuoteProvider
+    {
+        public string ProviderCode => MarketDataProviderCodes.YahooTest;
+        public int CallCount { get; private set; }
+
+        public Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+            IReadOnlyList<MarketQuoteRequest> requests,
+            CancellationToken cancellationToken)
+        {
+            var asOf = dates[Math.Min(CallCount, dates.Length - 1)];
+            CallCount++;
+            IReadOnlyList<MarketQuoteResult> quotes = requests.Select(request => new MarketQuoteResult(
+                request.InstrumentId,
+                ProviderCode,
+                request.ProviderSymbol,
+                request.Exchange,
+                request.Mic,
+                100m,
+                request.ExpectedCurrency,
+                "LATEST_AVAILABLE",
+                asOf,
+                fetchedAt,
+                true,
+                new string('c', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<MarketQuoteResult>(quotes, []));
+        }
+    }
+
     private sealed class CapturingExchangeRateProvider(DateTimeOffset fetchedAt) : IExchangeRateProvider
     {
         public string ProviderCode => "TEST_FX";
@@ -148,6 +250,36 @@ public sealed class InvestmentMarketDataServiceTests
                     fetchedAt,
                     false,
                     new string('a', 64)))
+                .ToList();
+            return Task.FromResult(new ProviderBatchResult<ExchangeRateResult>(rates, []));
+        }
+    }
+
+    private sealed class SequencedExchangeRateProvider(
+        DateTimeOffset fetchedAt,
+        params DateOnly[] dates) : IExchangeRateProvider
+    {
+        public string ProviderCode => "TEST_FX";
+        public int CallCount { get; private set; }
+
+        public Task<ProviderBatchResult<ExchangeRateResult>> GetLatestRatesAsync(
+            IReadOnlyCollection<string> quoteCurrencies,
+            DateOnly asOf,
+            CancellationToken cancellationToken)
+        {
+            var resultAsOf = dates[Math.Min(CallCount, dates.Length - 1)];
+            CallCount++;
+            IReadOnlyList<ExchangeRateResult> rates = quoteCurrencies
+                .Select(currency => new ExchangeRateResult(
+                    ProviderCode,
+                    "EUR",
+                    currency,
+                    2m,
+                    "TEST",
+                    resultAsOf,
+                    fetchedAt,
+                    false,
+                    new string('d', 64)))
                 .ToList();
             return Task.FromResult(new ProviderBatchResult<ExchangeRateResult>(rates, []));
         }


### PR DESCRIPTION
## O que mudou

- faz o refresh manual tentar novamente cotações e taxas de câmbio `STALE`, `BLOCKED` ou `MISSING`
- mantém a deduplicação diária para dados já `FRESH` e para o worker automático
- permite que falhas reais do provedor sejam retornadas após uma tentativa explícita
- adiciona regressões no serviço e no endpoint HTTP

## Causa raiz

O serviço considerava qualquer snapshot coletado no mesmo dia como já atualizado usando apenas `FetchedAt`. Assim, uma cotação antiga recebida no refresh automático bloqueava novas tentativas manuais durante todo o dia, mesmo permanecendo `STALE`.

## Impacto

O botão de atualização agora faz uma nova tentativa quando a fonte atual está desatualizada. Snapshots anteriores continuam preservados caso o provedor falhe ou retorne novamente uma data antiga.

## Validação

- `dotnet test CostTracker.sln --no-restore`: 67/67 testes passando
- testes específicos para cotação stale, câmbio stale e `POST /api/investments/market-data/refresh`
- `git diff --check`: limpo