### PR TITLE
Use Yahoo meta price when daily close is null

### DIFF
--- a/backend/CostTracker.Infrastructure/Investments/MarketData/YahooTestMarketQuoteProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/YahooTestMarketQuoteProvider.cs
@@ -121,58 +121,110 @@ public sealed class YahooTestMarketQuoteProvider(
         }
 
         var result = results[0];
-        if (!result.TryGetProperty("meta", out var meta) ||
-            !result.TryGetProperty("timestamp", out var timestamps) ||
-            timestamps.ValueKind != JsonValueKind.Array ||
-            !result.TryGetProperty("indicators", out var indicators) ||
-            !indicators.TryGetProperty("quote", out var quoteArrays) ||
-            quoteArrays.ValueKind != JsonValueKind.Array ||
-            quoteArrays.GetArrayLength() == 0 ||
-            !quoteArrays[0].TryGetProperty("close", out var closes) ||
-            closes.ValueKind != JsonValueKind.Array)
+        if (!result.TryGetProperty("meta", out var meta))
         {
             return false;
         }
 
-        var count = Math.Min(timestamps.GetArrayLength(), closes.GetArrayLength());
-        for (var index = count - 1; index >= 0; index--)
-        {
-            var close = closes[index];
-            if (close.ValueKind != JsonValueKind.Number || !close.TryGetDecimal(out var price) || price <= 0m ||
-                timestamps[index].ValueKind != JsonValueKind.Number || !timestamps[index].TryGetInt64(out var unixTimestamp))
-            {
-                continue;
-            }
+        var symbol = MarketDataParsing.GetString(meta, "symbol");
+        var currency = MarketDataParsing.NormalizeProviderCurrency(
+            MarketDataParsing.GetString(meta, "currency"));
+        if (string.IsNullOrWhiteSpace(symbol) || string.IsNullOrWhiteSpace(currency))
+            return false;
 
-            var timestamp = DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
-            var timezoneName = MarketDataParsing.GetString(meta, "exchangeTimezoneName");
+        var exchange = MarketDataParsing.GetString(meta, "fullExchangeName", "exchangeName");
+        var timezoneName = MarketDataParsing.GetString(meta, "exchangeTimezoneName");
+        ParsedQuote? latestClose = null;
+
+        if (result.TryGetProperty("timestamp", out var timestamps) &&
+            timestamps.ValueKind == JsonValueKind.Array &&
+            result.TryGetProperty("indicators", out var indicators) &&
+            indicators.TryGetProperty("quote", out var quoteArrays) &&
+            quoteArrays.ValueKind == JsonValueKind.Array &&
+            quoteArrays.GetArrayLength() > 0 &&
+            quoteArrays[0].TryGetProperty("close", out var closes) &&
+            closes.ValueKind == JsonValueKind.Array)
+        {
+            var count = Math.Min(timestamps.GetArrayLength(), closes.GetArrayLength());
+            for (var index = count - 1; index >= 0; index--)
+            {
+                var close = closes[index];
+                if (close.ValueKind != JsonValueKind.Number || !close.TryGetDecimal(out var price) || price <= 0m ||
+                    timestamps[index].ValueKind != JsonValueKind.Number || !timestamps[index].TryGetInt64(out var unixTimestamp) ||
+                    !TryConvertTimestamp(unixTimestamp, timezoneName, out var timestamp))
+                {
+                    continue;
+                }
+
+                latestClose = new ParsedQuote(
+                    symbol,
+                    exchange,
+                    currency,
+                    price,
+                    DateOnly.FromDateTime(timestamp.Date));
+                break;
+            }
+        }
+
+        ParsedQuote? regularMarketQuote = null;
+        if (MarketDataParsing.TryGetDecimal(meta, "regularMarketPrice", out var regularMarketPrice) &&
+            regularMarketPrice > 0m &&
+            meta.TryGetProperty("regularMarketTime", out var regularMarketTime) &&
+            regularMarketTime.ValueKind == JsonValueKind.Number &&
+            regularMarketTime.TryGetInt64(out var regularMarketUnixTimestamp) &&
+            TryConvertTimestamp(regularMarketUnixTimestamp, timezoneName, out var regularMarketTimestamp))
+        {
+            regularMarketQuote = new ParsedQuote(
+                symbol,
+                exchange,
+                currency,
+                regularMarketPrice,
+                DateOnly.FromDateTime(regularMarketTimestamp.Date));
+        }
+
+        if (regularMarketQuote is not null &&
+            (latestClose is null || regularMarketQuote.AsOf > latestClose.AsOf))
+        {
+            quote = regularMarketQuote;
+            return true;
+        }
+
+        if (latestClose is null)
+            return false;
+
+        quote = latestClose;
+        return true;
+    }
+
+    private static bool TryConvertTimestamp(
+        long unixTimestamp,
+        string? timezoneName,
+        out DateTimeOffset timestamp)
+    {
+        try
+        {
+            timestamp = DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
             if (!string.IsNullOrWhiteSpace(timezoneName))
             {
                 try
                 {
-                    timestamp = TimeZoneInfo.ConvertTime(timestamp, TimeZoneInfo.FindSystemTimeZoneById(timezoneName));
+                    timestamp = TimeZoneInfo.ConvertTime(
+                        timestamp,
+                        TimeZoneInfo.FindSystemTimeZoneById(timezoneName));
                 }
-                catch (TimeZoneNotFoundException)
+                catch (Exception exception) when (exception is TimeZoneNotFoundException or InvalidTimeZoneException)
                 {
-                    // UTC is deterministic when the host lacks the exchange timezone database.
+                    // UTC is deterministic when the host lacks valid exchange timezone data.
                 }
             }
 
-            var symbol = MarketDataParsing.GetString(meta, "symbol");
-            var currency = MarketDataParsing.GetString(meta, "currency");
-            if (string.IsNullOrWhiteSpace(symbol) || string.IsNullOrWhiteSpace(currency))
-                return false;
-
-            quote = new ParsedQuote(
-                symbol,
-                MarketDataParsing.GetString(meta, "fullExchangeName", "exchangeName"),
-                MarketDataParsing.NormalizeProviderCurrency(currency)!,
-                price,
-                DateOnly.FromDateTime(timestamp.Date));
             return true;
         }
-
-        return false;
+        catch (ArgumentOutOfRangeException)
+        {
+            timestamp = default;
+            return false;
+        }
     }
 
     private sealed record ParsedQuote(string Symbol, string? Exchange, string Currency, decimal Price, DateOnly AsOf);

--- a/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
+++ b/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
@@ -196,7 +196,9 @@ public class MarketDataProvidersTests
                     "symbol": "KO",
                     "currency": "USD",
                     "fullExchangeName": "NYSE",
-                    "exchangeTimezoneName": "America/New_York"
+                    "exchangeTimezoneName": "America/New_York",
+                    "regularMarketPrice": 71.00,
+                    "regularMarketTime": 1786395600
                   },
                   "timestamp": [1786305600, 1786392000],
                   "indicators": { "quote": [{ "close": [69.25, 70.50] }] }
@@ -220,6 +222,48 @@ public class MarketDataProvidersTests
         var quote = Assert.Single(result.Items);
         Assert.Empty(result.Failures);
         Assert.Equal(70.50m, quote.Price);
+        Assert.Equal("LATEST_AVAILABLE", quote.PriceKind);
+        Assert.True(quote.IsFallback);
+    }
+
+    [Fact]
+    public async Task PublicTestProvider_ShouldUseRegularMarketPriceWhenLatestDailyCloseIsNull()
+    {
+        const string payload = """
+            {
+              "chart": {
+                "result": [{
+                  "meta": {
+                    "symbol": "BAC",
+                    "currency": "USD",
+                    "fullExchangeName": "NYSE",
+                    "exchangeTimezoneName": "America/New_York",
+                    "regularMarketPrice": 63.89,
+                    "regularMarketTime": 1786996803
+                  },
+                  "timestamp": [1786714200, 1786973400],
+                  "indicators": { "quote": [{ "close": [64.49, null] }] }
+                }],
+                "error": null
+              }
+            }
+            """;
+        var provider = new YahooTestMarketQuoteProvider(
+            new HttpClient(new StubHttpMessageHandler(_ => JsonResponse(payload)))
+            {
+                BaseAddress = new Uri("https://query1.finance.yahoo.com/")
+            },
+            Options.Create(new MarketDataOptions { EnablePublicTestQuotes = true }),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BAC", "NYSE", "XNYS", "USD")],
+            CancellationToken.None);
+
+        var quote = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal(63.89m, quote.Price);
+        Assert.Equal(new DateOnly(2026, 8, 17), quote.AsOf);
         Assert.Equal("LATEST_AVAILABLE", quote.PriceKind);
         Assert.True(quote.IsFallback);
     }


### PR DESCRIPTION
## What changed

- reads `meta.regularMarketPrice` and `meta.regularMarketTime` from Yahoo chart responses
- uses the metadata quote only when it is newer than the latest valid daily close
- preserves the daily close when both values are from the same market date
- validates price, timestamp, symbol, currency, and exchange timezone
- adds a regression test based on the BAC production payload shape

## Why

Yahoo returned a candle for 2026-08-17 with a null `close`, while the metadata already contained the 2026-08-17 regular-market value. The adapter skipped the null candle and stored the older 2026-08-14 close, leaving the instrument stale.

## Impact

BAC and O can now use Yahoo's last regular-market value when the latest daily candle is incomplete. Yahoo remains explicitly marked as a public-test fallback.

## Validation

- `dotnet test backend/CostTracker.Tests/CostTracker.Tests.csproj --no-restore` — 68 passed
- `git diff --cached --check` — passed
- `dotnet format --verify-no-changes` could not start its MSBuild helper in the local sandbox and timed out; compilation and the full test suite passed