### PR TITLE
Show portfolio total and persistent refresh

### DIFF
--- a/frontend/src/features/investments/components/AllocationDonut.tsx
+++ b/frontend/src/features/investments/components/AllocationDonut.tsx
@@ -2,11 +2,12 @@ import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
 import { ASSET_CLASS_META, ASSET_CLASSES } from '../constants';
 import type { AssetClass } from '../types';
 import { formatPercent } from '../../../utils/format';
+import type { ReactNode } from 'react';
 
 interface AllocationDonutProps {
   values: Partial<Record<AssetClass, number>>;
   centerLabel?: string;
-  centerValue?: string;
+  centerValue?: ReactNode;
   title?: string;
 }
 
@@ -44,7 +45,7 @@ export function AllocationDonut({
         </ResponsiveContainer>
         <div className="allocation-chart-center">
           {centerValue && <strong>{centerValue}</strong>}
-          <span>{centerLabel}</span>
+          {centerLabel && <span>{centerLabel}</span>}
         </div>
       </div>
       <ul className="allocation-legend" aria-label="Resumo textual da distribuição">

--- a/frontend/src/features/investments/investments.css
+++ b/frontend/src/features/investments/investments.css
@@ -208,6 +208,28 @@
   font-size: 0.8rem;
 }
 
+.market-refresh-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.market-refresh-panel > div {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.market-refresh-panel small {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.market-refresh-panel .investment-alert {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
 .investment-unavailable {
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -1307,6 +1329,15 @@
   .investment-panel-header {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .market-refresh-panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .market-refresh-panel button {
+    width: 100%;
+    justify-content: center;
   }
 
   .investment-kpis,

--- a/frontend/src/features/investments/pages/PortfolioPage.test.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrivacyProvider } from '../../../contexts/PrivacyContext';
+import { PortfolioPage } from './PortfolioPage';
+
+vi.mock('../components/AllocationDonut', () => ({
+  AllocationDonut: ({ centerValue, centerLabel }: { centerValue?: ReactNode; centerLabel?: string }) => (
+    <div data-testid="allocation-donut">{centerValue}{centerLabel}</div>
+  )
+}));
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+    clear: vi.fn(() => values.clear())
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function apiResponse(value: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  }));
+}
+
+function renderPage(fetchMock: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal('fetch', fetchMock);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PrivacyProvider><PortfolioPage /></PrivacyProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('PortfolioPage', () => {
+  it('keeps manual market refresh available even when data is fresh', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/investments/portfolio/valuation')) {
+        return apiResponse({
+          id: 'portfolio-1',
+          isConfigured: true,
+          summary: { totalValueEur: 1250, freshness: 'FRESH', isPartial: false },
+          positions: [],
+          allocationTargets: []
+        });
+      }
+      if (url.endsWith('/investments/dividends/cash')) return apiResponse({ totalEur: 0, isPartial: false, balances: [] });
+      if (url.endsWith('/investments/market-data/refresh')) {
+        expect(init?.method).toBe('POST');
+        return apiResponse({ freshness: 'FRESH', message: 'Atualizado.' });
+      }
+      return apiResponse({ freshness: 'FRESH', message: 'Dados atualizados.' });
+    });
+    const user = userEvent.setup();
+    renderPage(fetchMock);
+
+    const refreshButton = await screen.findByRole('button', { name: 'Atualizar cotações agora' });
+    expect(screen.queryByText('Cotações desatualizadas')).not.toBeInTheDocument();
+    await user.click(refreshButton);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Cotações atualizadas.');
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/investments/market-data/refresh'),
+      expect.objectContaining({ method: 'POST' })
+    ));
+  });
+
+  it('hides the portfolio value in the donut when privacy mode is enabled', async () => {
+    localStorage.setItem('privacy-mode', '1');
+    renderPage(vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/investments/portfolio/valuation')) {
+        return apiResponse({
+          id: 'portfolio-1',
+          isConfigured: true,
+          summary: { totalValueEur: 1250, freshness: 'FRESH', isPartial: false },
+          positions: [],
+          allocationTargets: []
+        });
+      }
+      if (url.endsWith('/investments/dividends/cash')) return apiResponse({ totalEur: 0, isPartial: false, balances: [] });
+      return apiResponse({ freshness: 'FRESH' });
+    }));
+
+    await screen.findByRole('button', { name: 'Atualizar cotações agora' });
+    expect(within(screen.getByTestId('allocation-donut')).getByText('***')).toBeInTheDocument();
+    expect(screen.queryByText('Patrimônio')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/investments/pages/PortfolioPage.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.tsx
@@ -5,6 +5,7 @@ import { InvestmentApiError, investmentErrorMessage, investmentsApi } from '../a
 import { AllocationDonut } from '../components/AllocationDonut';
 import { DividendCashCard } from '../components/DividendCashCard';
 import { FxRatesPanel } from '../components/FxRatesPanel';
+import { InvestmentMoney } from '../components/InvestmentMoney';
 import { PortfolioKpis } from '../components/PortfolioKpis';
 import { PortfolioList } from '../components/PortfolioList';
 import { StatePanel } from '../components/StatePanel';
@@ -92,11 +93,25 @@ export function PortfolioPage() {
 
   return (
     <div className="investment-page-stack">
+      <section className="investment-panel market-refresh-panel">
+        <div>
+          <strong>Atualização de cotações</strong>
+          <small>Executada automaticamente às 06:00. Você também pode buscar os valores mais recentes a qualquer momento.</small>
+        </div>
+        <button type="button" disabled={refreshMutation.isPending} onClick={() => refreshMutation.mutate()}>
+          {refreshMutation.isPending ? 'A atualizar…' : 'Atualizar cotações agora'}
+        </button>
+        {refreshMutation.isError && <p className="investment-alert" data-tone="danger" role="alert">{investmentErrorMessage(refreshMutation.error, 'Não foi possível atualizar as cotações.')}</p>}
+        {refreshMutation.isSuccess && (
+          <p className="investment-alert" data-tone={refreshMutation.data.freshness === 'FRESH' ? undefined : 'warning'} role="status">
+            {refreshMutation.data.freshness === 'FRESH' ? 'Cotações atualizadas.' : refreshMutation.data.message || 'Atualização executada; alguns dados continuam pendentes.'}
+          </p>
+        )}
+      </section>
       {marketStatusQuery.data && marketStatusQuery.data.freshness !== 'FRESH' && (
         <StatePanel
           title={marketStatusQuery.data.freshness === 'STALE' ? 'Cotações desatualizadas' : 'Dados de mercado incompletos'}
           tone={marketStatusQuery.data.freshness === 'STALE' ? 'warning' : 'danger'}
-          action={<button type="button" disabled={refreshMutation.isPending} onClick={() => refreshMutation.mutate()}>{refreshMutation.isPending ? 'A atualizar…' : 'Atualizar dados'}</button>}
         >
           <p>{marketStatusQuery.data.message || 'Os valores exibidos usam o último snapshot disponível. Um novo aporte pode ficar bloqueado até a atualização.'}</p>
           {(marketStatusQuery.data.failures?.length ?? 0) > 0 && (
@@ -114,7 +129,8 @@ export function PortfolioPage() {
         <section className="investment-panel allocation-overview">
           <AllocationDonut
             values={distribution}
-            centerLabel={computedSummary.isPartial ? 'Subtotal' : 'Patrimônio'}
+            centerLabel=""
+            centerValue={<InvestmentMoney value={computedSummary.totalValueEur} />}
             title={computedSummary.isPartial ? 'Posições conhecidas por classe' : 'Carteira por classe'}
           />
         </section>


### PR DESCRIPTION
## O que mudou

- substitui o texto central do gráfico de alocação pelo valor total da carteira
- aplica ao valor central o mesmo modo de privacidade controlado pelo olho mágico
- mantém o botão `Atualizar cotações agora` sempre visível, inclusive quando os dados estão frescos
- preserva a rotina automática diária das 06:00
- mostra o resultado da tentativa manual e mantém o alerta detalhado quando algum dado continua pendente

## Por quê

O gráfico mostrava apenas a palavra “Patrimônio”, embora o valor consolidado fosse mais útil naquele espaço. O acionamento manual da atualização também só aparecia quando o status já estava desatualizado ou incompleto.

## Impacto

O usuário pode consultar o total diretamente no gráfico sem perder a privacidade e solicitar uma nova coleta de cotações sempre que quiser.

## Validação

- `npm test` — 31 testes
- `npm run build` — build de produção concluído