### PR TITLE
Improve mobile investment layout and decimal inputs

### DIFF
--- a/frontend/src/features/investments/components/DividendEventsPanel.tsx
+++ b/frontend/src/features/investments/components/DividendEventsPanel.tsx
@@ -11,9 +11,10 @@ import { investmentQueryKeys } from '../queryKeys';
 import type { CurrencyCode, DividendEventDto } from '../types';
 import { createIdempotencyKey } from '../utils';
 import { InvestmentMoney } from './InvestmentMoney';
+import { decimalTextSchema } from '../schemas';
 
 const dividendSchema = z.object({
-  grossAmountPerUnit: z.coerce.number().positive('Informe um valor positivo.'),
+  grossAmountPerUnit: decimalTextSchema({ message: 'Informe um valor positivo usando ponto como separador decimal.' }),
   withholdingTaxPercent: z.coerce.number().min(0).lt(100, 'O imposto deve ser inferior a 100%.'),
   currency: z.string().length(3),
   exDate: z.string().min(1, 'Informe a data ex.'),
@@ -45,7 +46,7 @@ export function DividendEventsPanel({ instrumentId, nativeCurrency }: { instrume
   const form = useForm<DividendForm>({
     resolver: zodResolver(dividendSchema),
     defaultValues: {
-      grossAmountPerUnit: 0,
+      grossAmountPerUnit: '',
       withholdingTaxPercent: 0,
       currency: nativeCurrency,
       exDate: '',
@@ -67,7 +68,7 @@ export function DividendEventsPanel({ instrumentId, nativeCurrency }: { instrume
       idempotencyKey: createIdempotencyKey('dividend-event')
     }),
     onSuccess: async () => {
-      form.reset({ grossAmountPerUnit: 0, withholdingTaxPercent: 0, currency: nativeCurrency, exDate: '', paymentDate: '', notes: '' });
+      form.reset({ grossAmountPerUnit: '', withholdingTaxPercent: 0, currency: nativeCurrency, exDate: '', paymentDate: '', notes: '' });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: investmentQueryKeys.dividends(instrumentId) }),
         queryClient.invalidateQueries({ queryKey: investmentQueryKeys.dividendCash() })
@@ -91,7 +92,7 @@ export function DividendEventsPanel({ instrumentId, nativeCurrency }: { instrume
         <summary>Cadastrar dividendo</summary>
         <p>A quantidade com direito será a que você possuía antes da data ex. O valor líquido entra no caixa às 06:00 do dia do pagamento.</p>
         <form className="compact-investment-form" onSubmit={form.handleSubmit((values) => createMutation.mutate(values))}>
-          <label><span>Valor bruto por ação/cota</span><input type="number" min={0} step="any" {...form.register('grossAmountPerUnit')} />{form.formState.errors.grossAmountPerUnit?.message && <small className="field-error">{form.formState.errors.grossAmountPerUnit.message}</small>}</label>
+          <label><span>Valor bruto por ação/cota</span><input type="text" autoCapitalize="none" autoCorrect="off" spellCheck={false} placeholder="0.00" {...form.register('grossAmountPerUnit')} />{form.formState.errors.grossAmountPerUnit?.message && <small className="field-error">{form.formState.errors.grossAmountPerUnit.message}</small>}</label>
           <label><span>Moeda</span><select {...form.register('currency')}>{currencies.map((currency) => <option key={currency} value={currency}>{currency}</option>)}</select></label>
           <label><span>Data ex</span><input type="date" {...form.register('exDate')} />{form.formState.errors.exDate?.message && <small className="field-error">{form.formState.errors.exDate.message}</small>}</label>
           <label><span>Data de pagamento</span><input type="date" min={exDate || undefined} {...form.register('paymentDate')} />{form.formState.errors.paymentDate?.message && <small className="field-error">{form.formState.errors.paymentDate.message}</small>}</label>

--- a/frontend/src/features/investments/components/InstrumentForm.test.tsx
+++ b/frontend/src/features/investments/components/InstrumentForm.test.tsx
@@ -35,4 +35,33 @@ describe('InstrumentForm', () => {
       }
     });
   });
+
+  it('accepts a dot-based unit cost as text and rejects a decimal comma', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<InstrumentForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Nome'), 'Apple');
+    await user.type(screen.getByLabelText('Ticker'), 'AAPL');
+    await user.type(screen.getByLabelText('Bolsa / MIC'), 'XNAS');
+    await user.selectOptions(screen.getByLabelText('Moeda nativa'), 'USD');
+    await user.click(screen.getByRole('checkbox'));
+    await user.type(screen.getByLabelText('Quantidade fracionária'), '2');
+    const unitCost = screen.getByLabelText('Custo unitário (opcional)');
+    expect(unitCost).toHaveAttribute('type', 'text');
+
+    await user.type(unitCost, '12,34');
+    await user.click(screen.getByRole('button', { name: /cadastrar ativo/i }));
+    expect(await screen.findByText('Use somente números e ponto como separador decimal.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.clear(unitCost);
+    await user.type(unitCost, '12.34');
+    await user.click(screen.getByRole('button', { name: /cadastrar ativo/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      openingTransaction: { quantity: 2, unitPrice: 12.34 }
+    });
+  });
 });

--- a/frontend/src/features/investments/components/InstrumentForm.tsx
+++ b/frontend/src/features/investments/components/InstrumentForm.tsx
@@ -197,7 +197,8 @@ export function InstrumentForm({ instrument, disabled, onSubmit }: InstrumentFor
                 </label>
                 <label>
                   <span>Custo unitário (opcional)</span>
-                  <input type="number" min={0} step="any" inputMode="decimal" {...register('openingUnitCost')} />
+                  <input type="text" autoCapitalize="none" autoCorrect="off" spellCheck={false} placeholder="0.00" {...register('openingUnitCost')} />
+                  {errors.openingUnitCost?.message && <small className="field-error">{errors.openingUnitCost.message}</small>}
                 </label>
               </>
             ) : (

--- a/frontend/src/features/investments/investments.css
+++ b/frontend/src/features/investments/investments.css
@@ -230,6 +230,40 @@
   margin: 0;
 }
 
+.portfolio-data-submenu {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-block: 0.65rem;
+}
+
+.portfolio-data-submenu > span {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.portfolio-data-submenu > div {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.portfolio-data-submenu button {
+  min-height: 34px;
+  padding: 0.35rem 0.65rem;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border-color: var(--border);
+  font-size: 0.75rem;
+}
+
+.portfolio-data-submenu button[aria-pressed="true"] {
+  color: var(--brand);
+  background: var(--brand-soft);
+  border-color: var(--brand-muted);
+}
+
 .investment-unavailable {
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -1338,6 +1372,22 @@
   .market-refresh-panel button {
     width: 100%;
     justify-content: center;
+  }
+
+  .portfolio-data-submenu {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .portfolio-data-submenu > div {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portfolio-data-submenu button {
+    min-height: 44px;
+    justify-content: center;
+    white-space: normal;
   }
 
   .investment-kpis,

--- a/frontend/src/features/investments/pages/ContributionPage.tsx
+++ b/frontend/src/features/investments/pages/ContributionPage.tsx
@@ -8,7 +8,7 @@ import { investmentErrorMessage, investmentsApi } from '../api';
 import { ContributionPreview } from '../components/ContributionPreview';
 import { InvestmentMoney } from '../components/InvestmentMoney';
 import { StatePanel } from '../components/StatePanel';
-import { contributionAmountSchema, type ContributionAmountFormValues } from '../schemas';
+import { contributionAmountSchema, decimalTextSchema, type ContributionAmountFormValues } from '../schemas';
 import { investmentQueryKeys } from '../queryKeys';
 import type { ContributionPlanDto } from '../types';
 import { createIdempotencyKey, todayIso } from '../utils';
@@ -21,7 +21,7 @@ const executionSchema = z.object({
     actualAmountEur: z.coerce.number().nonnegative(),
     actualNativeAmount: z.union([z.literal(''), z.coerce.number().nonnegative()]),
     actualQuantity: z.union([z.literal(''), z.coerce.number().nonnegative()]),
-    actualUnitPrice: z.union([z.literal(''), z.coerce.number().nonnegative()]),
+    actualUnitPrice: decimalTextSchema({ allowEmpty: true, allowZero: true }),
     fees: z.union([z.literal(''), z.coerce.number().nonnegative()]),
     currency: z.string()
   }))
@@ -108,7 +108,7 @@ export function ContributionPage() {
         actualAmountEur: line.recommendedAmountEur,
         actualNativeAmount: line.recommendedNativeAmount ?? '',
         actualQuantity: line.suggestedQuantity ?? '',
-        actualUnitPrice: line.unitPrice ?? '',
+        actualUnitPrice: line.unitPrice == null ? '' : String(line.unitPrice),
         fees: '',
         currency: line.nativeCurrency ?? 'EUR'
       }))
@@ -173,7 +173,7 @@ export function ContributionPage() {
                       <label><span>Valor na moeda do destino</span><input type="number" min={0} step="any" {...executionForm.register(`lines.${index}.actualNativeAmount`)} /></label>
                     )}
                     <label><span>Quantidade</span><input type="number" min={0} step="any" {...executionForm.register(`lines.${index}.actualQuantity`)} /></label>
-                    <label><span>Preço unitário</span><input type="number" min={0} step="any" {...executionForm.register(`lines.${index}.actualUnitPrice`)} /></label>
+                    <label><span>Preço unitário</span><input type="text" autoCapitalize="none" autoCorrect="off" spellCheck={false} placeholder="0.00" {...executionForm.register(`lines.${index}.actualUnitPrice`)} />{executionForm.formState.errors.lines?.[index]?.actualUnitPrice?.message && <small className="field-error">{executionForm.formState.errors.lines[index]?.actualUnitPrice?.message}</small>}</label>
                     <label><span>Taxas</span><input type="number" min={0} step="0.01" {...executionForm.register(`lines.${index}.fees`)} /></label>
                     <input type="hidden" {...executionForm.register(`lines.${index}.planLineId`)} />
                     {line?.instrumentId && <input type="hidden" {...executionForm.register(`lines.${index}.instrumentId`)} />}

--- a/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/features/investments/pages/InstrumentDetailPage.tsx
@@ -16,12 +16,13 @@ import { formatDateIsoToPt } from '../../../utils/format';
 import { PrivacyMask } from '../../../contexts/PrivacyContext';
 import { ConfirmModal } from '../../../components/ConfirmModal';
 import { DividendEventsPanel } from '../components/DividendEventsPanel';
+import { decimalTextSchema } from '../schemas';
 
 const transactionSchema = z.object({
   type: z.enum(['BUY', 'SELL', 'DEPOSIT', 'WITHDRAWAL', 'ADJUSTMENT']),
   occurredOn: z.string().min(1),
   quantity: z.union([z.literal(''), z.coerce.number().refine((value) => value !== 0, 'A quantidade não pode ser zero.')]),
-  unitPrice: z.union([z.literal(''), z.coerce.number().positive()]),
+  unitPrice: decimalTextSchema({ allowEmpty: true }),
   amount: z.union([z.literal(''), z.coerce.number().positive()]),
   fees: z.union([z.literal(''), z.coerce.number().nonnegative()]),
   exchangeRate: z.union([z.literal(''), z.coerce.number().positive()]),
@@ -45,7 +46,7 @@ const valuationSchema = z.object({
 });
 
 const quoteSchema = z.object({
-  price: z.coerce.number().positive('Informe uma cotação positiva.'),
+  price: decimalTextSchema({ message: 'Informe uma cotação positiva usando ponto como separador decimal.' }),
   currency: z.string().length(3),
   asOf: z.string().min(1),
   providerSymbol: z.string().max(128, 'O símbolo não pode exceder 128 caracteres.')
@@ -96,7 +97,7 @@ export function InstrumentDetailPage() {
   });
   const quoteForm = useForm<QuoteForm>({
     resolver: zodResolver(quoteSchema),
-    defaultValues: { price: 0, currency: '', asOf: todayIso(), providerSymbol: '' }
+    defaultValues: { price: '', currency: '', asOf: todayIso(), providerSymbol: '' }
   });
   const selectedTransactionType = transactionForm.watch('type');
 
@@ -135,7 +136,7 @@ export function InstrumentDetailPage() {
       mic: instrument?.mic || undefined
     }),
     onSuccess: async () => {
-      quoteForm.setValue('price', 0);
+      quoteForm.setValue('price', '');
       await queryClient.invalidateQueries({ queryKey: investmentQueryKeys.all });
     }
   });
@@ -207,7 +208,7 @@ export function InstrumentDetailPage() {
                 <label><span>Tipo</span><select {...transactionForm.register('type')}><option value="BUY">Compra</option><option value="SELL">Venda</option><option value="ADJUSTMENT">Ajuste</option></select></label>
                 <label><span>Data</span><input type="date" max={todayIso()} {...transactionForm.register('occurredOn')} /></label>
                 <label><span>Quantidade</span><input type="number" min={selectedTransactionType === 'ADJUSTMENT' ? undefined : 0} step="any" {...transactionForm.register('quantity')} />{transactionForm.formState.errors.quantity?.message && <small className="field-error">{transactionForm.formState.errors.quantity.message}</small>}</label>
-                <label><span>Preço unitário</span><input type="number" min={0} step="any" {...transactionForm.register('unitPrice')} />{transactionForm.formState.errors.unitPrice?.message && <small className="field-error">{transactionForm.formState.errors.unitPrice.message}</small>}</label>
+                <label><span>Preço unitário</span><input type="text" autoCapitalize="none" autoCorrect="off" spellCheck={false} placeholder="0.00" {...transactionForm.register('unitPrice')} />{transactionForm.formState.errors.unitPrice?.message && <small className="field-error">{transactionForm.formState.errors.unitPrice.message}</small>}</label>
                 <label><span>Taxas</span><input type="number" min={0} step="0.01" {...transactionForm.register('fees')} /></label>
                 <label><span>Moeda</span><select {...transactionForm.register('currency')}><option value={instrument.nativeCurrency}>{instrument.nativeCurrency}</option></select></label>
                 {instrument.nativeCurrency !== 'EUR' && <label><span>{instrument.nativeCurrency} por EUR na data (opcional)</span><input type="number" min={0} step="any" {...transactionForm.register('exchangeRate')} /></label>}
@@ -217,7 +218,7 @@ export function InstrumentDetailPage() {
                 <summary>Informar cotação manual de fallback</summary>
                 <p>Use apenas quando os provedores públicos não devolverem este ativo. O valor ficará identificado como manual.</p>
                 <form className="compact-investment-form" onSubmit={quoteForm.handleSubmit((values) => quoteMutation.mutate(values))}>
-                  <label><span>Preço atual</span><input type="number" min={0} step="any" {...quoteForm.register('price')} />{quoteForm.formState.errors.price?.message && <small className="field-error">{quoteForm.formState.errors.price.message}</small>}</label>
+                  <label><span>Preço atual</span><input type="text" autoCapitalize="none" autoCorrect="off" spellCheck={false} placeholder="0.00" {...quoteForm.register('price')} />{quoteForm.formState.errors.price?.message && <small className="field-error">{quoteForm.formState.errors.price.message}</small>}</label>
                   <label><span>Moeda</span><select {...quoteForm.register('currency')}><option value={instrument.nativeCurrency}>{instrument.nativeCurrency}</option></select></label>
                   <label><span>Data da cotação</span><input type="date" max={todayIso()} {...quoteForm.register('asOf')} /></label>
                   <label><span>Símbolo do provedor</span><input type="text" {...quoteForm.register('providerSymbol')} /></label>

--- a/frontend/src/features/investments/pages/PortfolioPage.test.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.test.tsx
@@ -78,6 +78,13 @@ describe('PortfolioPage', () => {
       expect.stringContaining('/investments/market-data/refresh'),
       expect.objectContaining({ method: 'POST' })
     ));
+
+    const dividendCashButton = screen.getByRole('button', { name: 'Caixa de dividendos' });
+    expect(dividendCashButton).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('heading', { name: 'Caixa de dividendos' })).not.toBeInTheDocument();
+    await user.click(dividendCashButton);
+    expect(await screen.findByRole('heading', { name: 'Caixa de dividendos' })).toBeInTheDocument();
+    expect(dividendCashButton).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('hides the portfolio value in the donut when privacy mode is enabled', async () => {

--- a/frontend/src/features/investments/pages/PortfolioPage.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.tsx
@@ -17,6 +17,7 @@ import { worstFreshness } from '../utils';
 export function PortfolioPage() {
   const queryClient = useQueryClient();
   const [selectedClass, setSelectedClass] = useState<InvestableAssetClass | 'ALL'>('ALL');
+  const [openDataPanel, setOpenDataPanel] = useState<'DIVIDENDS' | 'FX' | null>(null);
   const portfolioQuery = useQuery({
     queryKey: investmentQueryKeys.portfolio(),
     queryFn: investmentsApi.getPortfolio,
@@ -123,8 +124,27 @@ export function PortfolioPage() {
         </StatePanel>
       )}
       <PortfolioKpis summary={computedSummary} />
-      <DividendCashCard />
-      <FxRatesPanel positions={positions} />
+      <nav className="investment-panel portfolio-data-submenu" aria-label="Informações complementares da carteira">
+        <span>Informações complementares</span>
+        <div>
+          <button
+            type="button"
+            aria-pressed={openDataPanel === 'DIVIDENDS'}
+            onClick={() => setOpenDataPanel((current) => current === 'DIVIDENDS' ? null : 'DIVIDENDS')}
+          >
+            Caixa de dividendos
+          </button>
+          <button
+            type="button"
+            aria-pressed={openDataPanel === 'FX'}
+            onClick={() => setOpenDataPanel((current) => current === 'FX' ? null : 'FX')}
+          >
+            Câmbio utilizado
+          </button>
+        </div>
+      </nav>
+      {openDataPanel === 'DIVIDENDS' && <DividendCashCard />}
+      {openDataPanel === 'FX' && <FxRatesPanel positions={positions} />}
       <div className="portfolio-overview-grid">
         <section className="investment-panel allocation-overview">
           <AllocationDonut

--- a/frontend/src/features/investments/schemas.test.ts
+++ b/frontend/src/features/investments/schemas.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { decimalTextSchema } from './schemas';
+
+describe('decimalTextSchema', () => {
+  it('accepts dot decimals and rejects locale commas', () => {
+    const schema = decimalTextSchema();
+
+    expect(schema.safeParse('123.45').success).toBe(true);
+    expect(schema.safeParse('.75').success).toBe(true);
+    expect(schema.safeParse('123,45').success).toBe(false);
+    expect(schema.safeParse('0').success).toBe(false);
+  });
+
+  it('supports optional non-negative decimal text', () => {
+    const schema = decimalTextSchema({ allowEmpty: true, allowZero: true });
+
+    expect(schema.safeParse('').success).toBe(true);
+    expect(schema.safeParse('0').success).toBe(true);
+    expect(schema.safeParse('0.00').success).toBe(true);
+  });
+});

--- a/frontend/src/features/investments/schemas.ts
+++ b/frontend/src/features/investments/schemas.ts
@@ -1,6 +1,21 @@
 import { z } from 'zod';
 import { PERCENT_TOTAL } from './constants';
 
+const decimalTextPattern = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+export function decimalTextSchema({
+  allowEmpty = false,
+  allowZero = false,
+  message = 'Use somente números e ponto como separador decimal.'
+}: { allowEmpty?: boolean; allowZero?: boolean; message?: string } = {}) {
+  return z.string().trim().refine((value) => {
+    if (allowEmpty && value === '') return true;
+    if (!decimalTextPattern.test(value)) return false;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && (allowZero ? parsed >= 0 : parsed > 0);
+  }, message);
+}
+
 const investableAssetClassSchema = z.enum([
   'STOCKS',
   'REITS',
@@ -41,7 +56,7 @@ export const instrumentFormSchema = z.object({
   allocationScore: z.coerce.number().int().min(0).max(100),
   quantityStep: z.coerce.number().positive().max(1),
   openingQuantity: z.union([z.literal(''), z.coerce.number().positive()]),
-  openingUnitCost: z.union([z.literal(''), z.coerce.number().positive()]),
+  openingUnitCost: decimalTextSchema({ allowEmpty: true }),
   openingBalance: z.union([z.literal(''), z.coerce.number().nonnegative()]),
   asOf: z.string().min(1, 'Informe a data de referência.')
 }).superRefine((values, context) => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -619,6 +619,15 @@ input::placeholder {
   color: var(--text-secondary);
 }
 
+/* iOS Safari amplia automaticamente a página ao focar controles abaixo de 16px. */
+@supports (-webkit-touch-callout: none) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
 /* ===== Data Tables ===== */
 .data-table {
   width: 100%;


### PR DESCRIPTION
## O que mudou

- move Caixa de dividendos e Câmbio utilizado para um submenu compacto, fechado por padrão
- ajusta o submenu para duas ações de toque confortáveis em telas de smartphone
- evita o zoom automático do Safari no iOS ao focar campos de formulário
- troca cotação e valores unitários por campos de texto com validação explícita que aceita ponto e rejeita vírgula
- aplica a mesma regra ao custo inicial, preço de transação, cotação manual, preço executado de aporte e valor unitário de dividendos

## Por quê

A exibição permanente das informações complementares deixava a carteira carregada em telas pequenas. Além disso, o Safari no iOS amplia controles com fonte menor que 16 px e o teclado numérico localizado pode não disponibilizar ponto, impedindo o formato decimal esperado pelo backend.

## Impacto

No celular, as informações complementares ocupam espaço somente quando abertas. Os campos financeiros relevantes exibem o teclado de texto, aceitam valores como `12.34` e apresentam erro de formulário para `12,34`.

## Validação

- `npm run build`
- `npm test` — 16 arquivos, 34 testes aprovados
- `git diff --check`