### PR TITLE
Move investment data to dedicated pages

### DIFF
--- a/frontend/src/features/investments/InvestmentsPage.tsx
+++ b/frontend/src/features/investments/InvestmentsPage.tsx
@@ -2,6 +2,8 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { InvestmentsShell } from './components/InvestmentsShell';
 import { AllocationPage } from './pages/AllocationPage';
 import { ContributionPage } from './pages/ContributionPage';
+import { DividendCashPage } from './pages/DividendCashPage';
+import { FxRatesPage } from './pages/FxRatesPage';
 import { InstrumentDetailPage } from './pages/InstrumentDetailPage';
 import { InstrumentFormPage } from './pages/InstrumentFormPage';
 import { PortfolioPage } from './pages/PortfolioPage';
@@ -15,6 +17,8 @@ export function InvestmentsPage() {
         <Route path="alocacao" element={<AllocationPage />} />
         <Route path="aporte" element={<ContributionPage />} />
         <Route path="ativos/novo" element={<InstrumentFormPage />} />
+        <Route path="dividendos" element={<DividendCashPage />} />
+        <Route path="cambio" element={<FxRatesPage />} />
         <Route path="ativos/:instrumentId/editar" element={<InstrumentFormPage />} />
         <Route path="ativos/:instrumentId" element={<InstrumentDetailPage />} />
         <Route path="*" element={<Navigate to="/investimentos" replace />} />

--- a/frontend/src/features/investments/components/FxRatesPanel.tsx
+++ b/frontend/src/features/investments/components/FxRatesPanel.tsx
@@ -16,13 +16,12 @@ export function FxRatesPanel({ positions }: { positions: InstrumentPositionDto[]
       .map((rate) => [`${rate!.baseCurrency}/${rate!.quoteCurrency}`, rate!] as const)
   ).values());
 
-  if (rates.length === 0) return null;
-
   return (
     <section className="investment-panel fx-rates-panel">
       <header className="investment-panel-header">
         <div><h2>Câmbio utilizado</h2><p>Taxas efetivamente usadas para converter as posições para EUR.</p></div>
       </header>
+      {rates.length === 0 && <p className="investment-empty-copy">Nenhuma conversão de moeda foi utilizada nas posições atuais.</p>}
       <div className="fx-rate-list">
         {rates.map((rate) => (
           <article key={`${rate.baseCurrency}/${rate.quoteCurrency}`}>

--- a/frontend/src/features/investments/components/InvestmentsShell.test.tsx
+++ b/frontend/src/features/investments/components/InvestmentsShell.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { InvestmentsShell } from './InvestmentsShell';
+
+describe('InvestmentsShell', () => {
+  it('links dividend cash and used exchange rates to dedicated pages', () => {
+    render(
+      <MemoryRouter initialEntries={['/investimentos/dividendos']}>
+        <InvestmentsShell><p>Conteúdo da página</p></InvestmentsShell>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'Cadastrar ativo' })).toHaveAttribute('href', '/investimentos/ativos/novo');
+    expect(screen.getByRole('link', { name: 'Caixa de dividendos' })).toHaveAttribute('href', '/investimentos/dividendos');
+    expect(screen.getByRole('link', { name: 'Caixa de dividendos' })).toHaveClass('active');
+    expect(screen.getByRole('link', { name: 'Câmbio utilizado' })).toHaveAttribute('href', '/investimentos/cambio');
+  });
+});

--- a/frontend/src/features/investments/components/InvestmentsShell.tsx
+++ b/frontend/src/features/investments/components/InvestmentsShell.tsx
@@ -18,6 +18,8 @@ export function InvestmentsShell({ children }: { children: ReactNode }) {
         <NavLink to="/investimentos/alocacao">Alocação</NavLink>
         <NavLink to="/investimentos/aporte">Novo aporte</NavLink>
         <NavLink to="/investimentos/ativos/novo">Cadastrar ativo</NavLink>
+        <NavLink to="/investimentos/dividendos">Caixa de dividendos</NavLink>
+        <NavLink to="/investimentos/cambio">Câmbio utilizado</NavLink>
       </nav>
 
       {children}

--- a/frontend/src/features/investments/investments.css
+++ b/frontend/src/features/investments/investments.css
@@ -230,40 +230,6 @@
   margin: 0;
 }
 
-.portfolio-data-submenu {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding-block: 0.65rem;
-}
-
-.portfolio-data-submenu > span {
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-  font-weight: 650;
-}
-
-.portfolio-data-submenu > div {
-  display: flex;
-  gap: 0.4rem;
-}
-
-.portfolio-data-submenu button {
-  min-height: 34px;
-  padding: 0.35rem 0.65rem;
-  color: var(--text-secondary);
-  background: var(--surface-raised);
-  border-color: var(--border);
-  font-size: 0.75rem;
-}
-
-.portfolio-data-submenu button[aria-pressed="true"] {
-  color: var(--brand);
-  background: var(--brand-soft);
-  border-color: var(--brand-muted);
-}
-
 .investment-unavailable {
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -1372,22 +1338,6 @@
   .market-refresh-panel button {
     width: 100%;
     justify-content: center;
-  }
-
-  .portfolio-data-submenu {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .portfolio-data-submenu > div {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .portfolio-data-submenu button {
-    min-height: 44px;
-    justify-content: center;
-    white-space: normal;
   }
 
   .investment-kpis,

--- a/frontend/src/features/investments/pages/DividendCashPage.tsx
+++ b/frontend/src/features/investments/pages/DividendCashPage.tsx
@@ -1,0 +1,9 @@
+import { DividendCashCard } from '../components/DividendCashCard';
+
+export function DividendCashPage() {
+  return (
+    <div className="investment-page-stack">
+      <DividendCashCard />
+    </div>
+  );
+}

--- a/frontend/src/features/investments/pages/FxRatesPage.tsx
+++ b/frontend/src/features/investments/pages/FxRatesPage.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { investmentErrorMessage, investmentsApi } from '../api';
+import { FxRatesPanel } from '../components/FxRatesPanel';
+import { StatePanel } from '../components/StatePanel';
+import { investmentQueryKeys } from '../queryKeys';
+
+export function FxRatesPage() {
+  const portfolioQuery = useQuery({
+    queryKey: investmentQueryKeys.portfolio(),
+    queryFn: investmentsApi.getPortfolio,
+    retry: false
+  });
+
+  if (portfolioQuery.isLoading) {
+    return <StatePanel title="A carregar o câmbio…"><p>A reunir as taxas utilizadas nas posições da carteira.</p></StatePanel>;
+  }
+
+  if (portfolioQuery.isError) {
+    return (
+      <StatePanel title="Não foi possível carregar o câmbio" tone="danger" action={<button type="button" onClick={() => void portfolioQuery.refetch()}>Tentar novamente</button>}>
+        <p>{investmentErrorMessage(portfolioQuery.error)}</p>
+      </StatePanel>
+    );
+  }
+
+  return (
+    <div className="investment-page-stack">
+      <FxRatesPanel positions={portfolioQuery.data?.positions ?? []} />
+    </div>
+  );
+}

--- a/frontend/src/features/investments/pages/PortfolioPage.test.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.test.tsx
@@ -79,12 +79,8 @@ describe('PortfolioPage', () => {
       expect.objectContaining({ method: 'POST' })
     ));
 
-    const dividendCashButton = screen.getByRole('button', { name: 'Caixa de dividendos' });
-    expect(dividendCashButton).toHaveAttribute('aria-pressed', 'false');
     expect(screen.queryByRole('heading', { name: 'Caixa de dividendos' })).not.toBeInTheDocument();
-    await user.click(dividendCashButton);
-    expect(await screen.findByRole('heading', { name: 'Caixa de dividendos' })).toBeInTheDocument();
-    expect(dividendCashButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByRole('heading', { name: 'Câmbio utilizado' })).not.toBeInTheDocument();
   });
 
   it('hides the portfolio value in the donut when privacy mode is enabled', async () => {

--- a/frontend/src/features/investments/pages/PortfolioPage.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.tsx
@@ -3,8 +3,6 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { InvestmentApiError, investmentErrorMessage, investmentsApi } from '../api';
 import { AllocationDonut } from '../components/AllocationDonut';
-import { DividendCashCard } from '../components/DividendCashCard';
-import { FxRatesPanel } from '../components/FxRatesPanel';
 import { InvestmentMoney } from '../components/InvestmentMoney';
 import { PortfolioKpis } from '../components/PortfolioKpis';
 import { PortfolioList } from '../components/PortfolioList';
@@ -17,7 +15,6 @@ import { worstFreshness } from '../utils';
 export function PortfolioPage() {
   const queryClient = useQueryClient();
   const [selectedClass, setSelectedClass] = useState<InvestableAssetClass | 'ALL'>('ALL');
-  const [openDataPanel, setOpenDataPanel] = useState<'DIVIDENDS' | 'FX' | null>(null);
   const portfolioQuery = useQuery({
     queryKey: investmentQueryKeys.portfolio(),
     queryFn: investmentsApi.getPortfolio,
@@ -124,27 +121,6 @@ export function PortfolioPage() {
         </StatePanel>
       )}
       <PortfolioKpis summary={computedSummary} />
-      <nav className="investment-panel portfolio-data-submenu" aria-label="Informações complementares da carteira">
-        <span>Informações complementares</span>
-        <div>
-          <button
-            type="button"
-            aria-pressed={openDataPanel === 'DIVIDENDS'}
-            onClick={() => setOpenDataPanel((current) => current === 'DIVIDENDS' ? null : 'DIVIDENDS')}
-          >
-            Caixa de dividendos
-          </button>
-          <button
-            type="button"
-            aria-pressed={openDataPanel === 'FX'}
-            onClick={() => setOpenDataPanel((current) => current === 'FX' ? null : 'FX')}
-          >
-            Câmbio utilizado
-          </button>
-        </div>
-      </nav>
-      {openDataPanel === 'DIVIDENDS' && <DividendCashCard />}
-      {openDataPanel === 'FX' && <FxRatesPanel positions={positions} />}
       <div className="portfolio-overview-grid">
         <section className="investment-panel allocation-overview">
           <AllocationDonut


### PR DESCRIPTION
## O que mudou

- adiciona **Caixa de dividendos** e **Câmbio utilizado** à navegação principal de Investimentos, ao lado de **Cadastrar ativo**
- cria uma rota e uma página próprias para cada item
- remove o submenu expansível e os painéis da tela da Carteira
- mostra uma mensagem vazia na página de câmbio quando nenhuma conversão foi utilizada

## Por quê

Esses conteúdos devem seguir o mesmo comportamento de **Cadastrar ativo**: o clique navega para uma tela separada, sem expandir conteúdo dentro da Carteira.

## Impacto

A Carteira fica mais limpa e cada informação complementar pode ser acessada diretamente por uma URL própria:

- `/investimentos/dividendos`
- `/investimentos/cambio`

## Validação

- `npm run build`
- `npm test` — 17 arquivos e 35 testes aprovados
- `git diff --check`