### PR TITLE
Move market refresh to the investment header

### DIFF
--- a/frontend/src/features/investments/components/InvestmentsShell.test.tsx
+++ b/frontend/src/features/investments/components/InvestmentsShell.test.tsx
@@ -1,19 +1,56 @@
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InvestmentsShell } from './InvestmentsShell';
 
-describe('InvestmentsShell', () => {
-  it('links dividend cash and used exchange rates to dedicated pages', () => {
-    render(
+function renderShell() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/investimentos/dividendos']}>
         <InvestmentsShell><p>Conteúdo da página</p></InvestmentsShell>
       </MemoryRouter>
-    );
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('InvestmentsShell', () => {
+  it('links dividend cash and used exchange rates to dedicated pages', () => {
+    renderShell();
 
     expect(screen.getByRole('link', { name: 'Cadastrar ativo' })).toHaveAttribute('href', '/investimentos/ativos/novo');
     expect(screen.getByRole('link', { name: 'Caixa de dividendos' })).toHaveAttribute('href', '/investimentos/dividendos');
     expect(screen.getByRole('link', { name: 'Caixa de dividendos' })).toHaveClass('active');
     expect(screen.getByRole('link', { name: 'Câmbio utilizado' })).toHaveAttribute('href', '/investimentos/cambio');
+  });
+
+  it('refreshes market data from the heading action', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe('POST');
+      return Promise.resolve(new Response(JSON.stringify({ freshness: 'FRESH', message: 'Atualizado.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    renderShell();
+
+    const refreshButton = screen.getByRole('button', { name: 'Atualizar cotações agora' });
+    expect(refreshButton).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Planejar aporte' })).toBeInTheDocument();
+    await user.click(refreshButton);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Cotações atualizadas.');
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/investments/market-data/refresh'),
+      expect.objectContaining({ method: 'POST' })
+    ));
   });
 });

--- a/frontend/src/features/investments/components/InvestmentsShell.tsx
+++ b/frontend/src/features/investments/components/InvestmentsShell.tsx
@@ -1,7 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { NavLink } from 'react-router-dom';
 import type { ReactNode } from 'react';
+import { investmentErrorMessage, investmentsApi } from '../api';
+import { investmentQueryKeys } from '../queryKeys';
 
 export function InvestmentsShell({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const refreshMutation = useMutation({
+    mutationFn: investmentsApi.refreshMarketData,
+    onSuccess: async (status) => {
+      await queryClient.invalidateQueries({ queryKey: investmentQueryKeys.all });
+      queryClient.setQueryData(investmentQueryKeys.marketDataStatus(), status);
+    }
+  });
+
   return (
     <div className="investments-shell">
       <header className="investments-heading">
@@ -10,7 +22,29 @@ export function InvestmentsShell({ children }: { children: ReactNode }) {
           <h1>Investimentos</h1>
           <p>Acompanhe posições, metas e aportes sem misturar a carteira com o orçamento mensal.</p>
         </div>
-        <NavLink className="investment-primary-link" to="/investimentos/aporte">Planejar aporte</NavLink>
+        <div className="investments-heading-actions">
+          <div className="investments-heading-action-row">
+            <button
+              className="investment-secondary-link"
+              type="button"
+              disabled={refreshMutation.isPending}
+              onClick={() => refreshMutation.mutate()}
+            >
+              {refreshMutation.isPending ? 'A atualizar…' : 'Atualizar cotações agora'}
+            </button>
+            <NavLink className="investment-primary-link" to="/investimentos/aporte">Planejar aporte</NavLink>
+          </div>
+          {refreshMutation.isError && (
+            <small className="investments-heading-feedback" data-tone="danger" role="alert">
+              {investmentErrorMessage(refreshMutation.error, 'Não foi possível atualizar as cotações.')}
+            </small>
+          )}
+          {refreshMutation.isSuccess && (
+            <small className="investments-heading-feedback" data-tone={refreshMutation.data.freshness === 'FRESH' ? undefined : 'warning'} role="status">
+              {refreshMutation.data.freshness === 'FRESH' ? 'Cotações atualizadas.' : refreshMutation.data.message || 'Atualização executada; alguns dados continuam pendentes.'}
+            </small>
+          )}
+        </div>
       </header>
 
       <nav className="investments-tabs" aria-label="Navegação de investimentos">

--- a/frontend/src/features/investments/investments.css
+++ b/frontend/src/features/investments/investments.css
@@ -23,6 +23,33 @@
   letter-spacing: -0.04em;
 }
 
+.investments-heading-actions {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: end;
+}
+
+.investments-heading-action-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.investments-heading-feedback {
+  max-width: 30rem;
+  color: var(--success);
+  font-size: 0.72rem;
+  text-align: right;
+}
+
+.investments-heading-feedback[data-tone="warning"] {
+  color: var(--warning);
+}
+
+.investments-heading-feedback[data-tone="danger"] {
+  color: var(--danger);
+}
+
 .investments-heading p,
 .investment-panel-header p,
 .allocation-editor-fields header p,
@@ -206,28 +233,6 @@
   margin: 0;
   color: var(--text-secondary);
   font-size: 0.8rem;
-}
-
-.market-refresh-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.75rem 1rem;
-}
-
-.market-refresh-panel > div {
-  display: grid;
-  gap: 0.18rem;
-}
-
-.market-refresh-panel small {
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-}
-
-.market-refresh-panel .investment-alert {
-  grid-column: 1 / -1;
-  margin: 0;
 }
 
 .investment-unavailable {
@@ -1274,6 +1279,16 @@
     padding: 1rem;
   }
 
+  .investments-heading-actions {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .investments-heading-feedback {
+    max-width: none;
+    text-align: left;
+  }
+
   .portfolio-overview-grid,
   .allocation-editor,
   .instrument-detail-grid {
@@ -1308,8 +1323,15 @@
     border-radius: var(--radius-sm);
   }
 
-  .investments-heading .investment-primary-link {
+  .investments-heading-action-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     width: 100%;
+  }
+
+  .investments-heading-action-row > * {
+    min-height: 44px;
+    white-space: normal;
   }
 
   .investments-tabs {
@@ -1329,15 +1351,6 @@
   .investment-panel-header {
     align-items: stretch;
     flex-direction: column;
-  }
-
-  .market-refresh-panel {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .market-refresh-panel button {
-    width: 100%;
-    justify-content: center;
   }
 
   .investment-kpis,

--- a/frontend/src/features/investments/pages/PortfolioPage.test.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -47,8 +46,8 @@ function renderPage(fetchMock: ReturnType<typeof vi.fn>) {
 }
 
 describe('PortfolioPage', () => {
-  it('keeps manual market refresh available even when data is fresh', async () => {
-    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+  it('does not render the market refresh control inside the portfolio', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/investments/portfolio/valuation')) {
         return apiResponse({
@@ -60,25 +59,14 @@ describe('PortfolioPage', () => {
         });
       }
       if (url.endsWith('/investments/dividends/cash')) return apiResponse({ totalEur: 0, isPartial: false, balances: [] });
-      if (url.endsWith('/investments/market-data/refresh')) {
-        expect(init?.method).toBe('POST');
-        return apiResponse({ freshness: 'FRESH', message: 'Atualizado.' });
-      }
       return apiResponse({ freshness: 'FRESH', message: 'Dados atualizados.' });
     });
-    const user = userEvent.setup();
     renderPage(fetchMock);
 
-    const refreshButton = await screen.findByRole('button', { name: 'Atualizar cotações agora' });
+    await screen.findByTestId('allocation-donut');
+    expect(screen.queryByRole('button', { name: 'Atualizar cotações agora' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Atualização de cotações')).not.toBeInTheDocument();
     expect(screen.queryByText('Cotações desatualizadas')).not.toBeInTheDocument();
-    await user.click(refreshButton);
-
-    expect(await screen.findByRole('status')).toHaveTextContent('Cotações atualizadas.');
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/investments/market-data/refresh'),
-      expect.objectContaining({ method: 'POST' })
-    ));
-
     expect(screen.queryByRole('heading', { name: 'Caixa de dividendos' })).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Câmbio utilizado' })).not.toBeInTheDocument();
   });
@@ -100,7 +88,7 @@ describe('PortfolioPage', () => {
       return apiResponse({ freshness: 'FRESH' });
     }));
 
-    await screen.findByRole('button', { name: 'Atualizar cotações agora' });
+    await screen.findByTestId('allocation-donut');
     expect(within(screen.getByTestId('allocation-donut')).getByText('***')).toBeInTheDocument();
     expect(screen.queryByText('Patrimônio')).not.toBeInTheDocument();
   });

--- a/frontend/src/features/investments/pages/PortfolioPage.tsx
+++ b/frontend/src/features/investments/pages/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { InvestmentApiError, investmentErrorMessage, investmentsApi } from '../api';
@@ -13,7 +13,6 @@ import type { AssetClass, InvestableAssetClass, PortfolioSummaryDto } from '../t
 import { worstFreshness } from '../utils';
 
 export function PortfolioPage() {
-  const queryClient = useQueryClient();
   const [selectedClass, setSelectedClass] = useState<InvestableAssetClass | 'ALL'>('ALL');
   const portfolioQuery = useQuery({
     queryKey: investmentQueryKeys.portfolio(),
@@ -26,17 +25,6 @@ export function PortfolioPage() {
     enabled: portfolioQuery.isSuccess && portfolioQuery.data.configured,
     retry: false
   });
-  const refreshMutation = useMutation({
-    mutationFn: investmentsApi.refreshMarketData,
-    onSuccess: async (status) => {
-      queryClient.setQueryData(investmentQueryKeys.marketDataStatus(), status);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: investmentQueryKeys.portfolio() }),
-        queryClient.invalidateQueries({ queryKey: investmentQueryKeys.instruments() })
-      ]);
-    }
-  });
-
   const needsOnboarding = (portfolioQuery.error instanceof InvestmentApiError && portfolioQuery.error.status === 404)
     || portfolioQuery.data?.configured === false;
   const portfolio = portfolioQuery.data;
@@ -91,21 +79,6 @@ export function PortfolioPage() {
 
   return (
     <div className="investment-page-stack">
-      <section className="investment-panel market-refresh-panel">
-        <div>
-          <strong>Atualização de cotações</strong>
-          <small>Executada automaticamente às 06:00. Você também pode buscar os valores mais recentes a qualquer momento.</small>
-        </div>
-        <button type="button" disabled={refreshMutation.isPending} onClick={() => refreshMutation.mutate()}>
-          {refreshMutation.isPending ? 'A atualizar…' : 'Atualizar cotações agora'}
-        </button>
-        {refreshMutation.isError && <p className="investment-alert" data-tone="danger" role="alert">{investmentErrorMessage(refreshMutation.error, 'Não foi possível atualizar as cotações.')}</p>}
-        {refreshMutation.isSuccess && (
-          <p className="investment-alert" data-tone={refreshMutation.data.freshness === 'FRESH' ? undefined : 'warning'} role="status">
-            {refreshMutation.data.freshness === 'FRESH' ? 'Cotações atualizadas.' : refreshMutation.data.message || 'Atualização executada; alguns dados continuam pendentes.'}
-          </p>
-        )}
-      </section>
       {marketStatusQuery.data && marketStatusQuery.data.freshness !== 'FRESH' && (
         <StatePanel
           title={marketStatusQuery.data.freshness === 'STALE' ? 'Cotações desatualizadas' : 'Dados de mercado incompletos'}


### PR DESCRIPTION
## O que mudou

- move **Atualizar cotações agora** para o cabeçalho de Investimentos, ao lado de **Planejar aporte**
- mantém a ação disponível em todas as telas da área de Investimentos
- remove o painel dedicado de atualização da Carteira
- exibe sucesso, atualização parcial ou erro de forma compacta no cabeçalho
- em smartphones, organiza as duas ações em duas colunas com área de toque de 44 px

## Por quê

A atualização manual não precisa ocupar um painel completo dentro da Carteira. Como ação global da área de Investimentos, ela fica mais acessível e reduz um bloco visual da página.

## Impacto

A rotina das 06:00 permanece inalterada. O botão manual continua sempre disponível e só fica desabilitado enquanto uma atualização está em andamento.

## Validação

- `npm run build`
- `npm test` — 17 arquivos e 36 testes aprovados
- `git diff --check`