### PR TITLE
Fix Marketstack fallback for stale quotes

### DIFF
--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -492,6 +492,7 @@ public sealed class InvestmentMarketDataService(
         var unresolved = instruments
             .Where(item => !refreshedToday.Contains(item.Id))
             .ToDictionary(item => item.Id);
+        var instrumentsWithAcceptedQuote = new HashSet<Guid>();
 
         foreach (var provider in _quoteProviders)
         {
@@ -558,17 +559,23 @@ public sealed class InvestmentMarketDataService(
                 }
 
                 if (TryAddQuoteSnapshot(quote, today))
-                    unresolved.Remove(quote.InstrumentId);
+                {
+                    instrumentsWithAcceptedQuote.Add(quote.InstrumentId);
+                    if (ClassifyQuote(quote.AsOf, today) != DataFreshnessCodes.Blocked)
+                        unresolved.Remove(quote.InstrumentId);
+                }
                 else
                     failures.Add(new ProviderFailure(quote.Provider, quote.ProviderSymbol, "Provider quote failed validation.", false));
             }
         }
 
-        failures.AddRange(unresolved.Values.Select(instrument => new ProviderFailure(
-            "ALL",
-            instrument.Ticker ?? instrument.Name,
-            "No configured provider returned a quote for this instrument.",
-            false)));
+        failures.AddRange(unresolved.Values
+            .Where(instrument => !instrumentsWithAcceptedQuote.Contains(instrument.Id))
+            .Select(instrument => new ProviderFailure(
+                "ALL",
+                instrument.Ticker ?? instrument.Name,
+                "No configured provider returned a quote for this instrument.",
+                false)));
     }
 
     private static string? ResolveProviderSymbol(string providerCode, string? ticker, string? mic)

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/MarketstackMarketQuoteProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/MarketstackMarketQuoteProvider.cs
@@ -36,7 +36,7 @@ public sealed class MarketstackMarketQuoteProvider(
         {
             try
             {
-                var uri = $"v2/eod/latest?access_key={Uri.EscapeDataString(options.Value.MarketstackApiKey)}" +
+                var uri = $"v1/eod/latest?access_key={Uri.EscapeDataString(options.Value.MarketstackApiKey)}" +
                           $"&symbols={Uri.EscapeDataString(request.ProviderSymbol)}";
                 using var response = await httpClient.GetAsync(uri, cancellationToken);
                 var payload = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -146,6 +146,57 @@ public sealed class InvestmentMarketDataServiceTests
             asOf => Assert.Equal(new DateOnly(2026, 8, 17), asOf));
     }
 
+    [Fact]
+    public async Task Refresh_ShouldContinueToFallbackWhenAProviderReturnsABlockedQuote()
+    {
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"market-blocked-fallback-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var portfolio = InvestmentPortfolio.Create(FixedNow);
+        var instrument = CreateQuotedInstrument(portfolio, "BARC", "XLON");
+        portfolio.Instruments.Add(instrument);
+        dbContext.InvestmentPortfolios.Add(portfolio);
+        await dbContext.SaveChangesAsync();
+
+        var blockedProvider = new FixedQuoteProvider(
+            "BLOCKED_PRIMARY",
+            FixedNow,
+            new DateOnly(2023, 10, 18),
+            1.5164m);
+        var freshProvider = new FixedQuoteProvider(
+            "YAHOO_TEST",
+            FixedNow,
+            new DateOnly(2026, 8, 10),
+            5.1420m);
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [blockedProvider, freshProvider],
+            [new CapturingExchangeRateProvider(FixedNow)],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions
+            {
+                RefreshTimeZone = "Europe/Lisbon",
+                EnablePublicTestQuotes = true,
+                QuoteWarningSessions = 1,
+                QuoteBlockingSessions = 2
+            }),
+            new FixedTimeProvider(FixedNow));
+
+        var status = await service.RefreshAsync();
+
+        Assert.Equal(DataFreshnessCodes.Fresh, status.Freshness);
+        Assert.Equal(1, blockedProvider.CallCount);
+        Assert.Equal(1, freshProvider.CallCount);
+        var snapshots = await dbContext.MarketQuoteSnapshots
+            .Where(item => item.InstrumentId == instrument.Id)
+            .OrderBy(item => item.AsOf)
+            .ToListAsync();
+        Assert.Equal(2, snapshots.Count);
+        Assert.Equal("YAHOO_TEST", snapshots[^1].ProviderCode);
+        Assert.Equal(5.1420m, snapshots[^1].Price);
+    }
+
     private static InvestmentInstrument CreateQuotedInstrument(
         InvestmentPortfolio portfolio,
         string ticker,
@@ -222,6 +273,37 @@ public sealed class InvestmentMarketDataServiceTests
                 fetchedAt,
                 true,
                 new string('c', 64))).ToList();
+            return Task.FromResult(new ProviderBatchResult<MarketQuoteResult>(quotes, []));
+        }
+    }
+
+    private sealed class FixedQuoteProvider(
+        string providerCode,
+        DateTimeOffset fetchedAt,
+        DateOnly asOf,
+        decimal price) : IMarketQuoteProvider
+    {
+        public string ProviderCode => providerCode;
+        public int CallCount { get; private set; }
+
+        public Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+            IReadOnlyList<MarketQuoteRequest> requests,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            IReadOnlyList<MarketQuoteResult> quotes = requests.Select(request => new MarketQuoteResult(
+                request.InstrumentId,
+                ProviderCode,
+                request.ProviderSymbol,
+                request.Exchange,
+                request.Mic,
+                price,
+                request.ExpectedCurrency,
+                "EOD_CLOSE",
+                asOf,
+                fetchedAt,
+                true,
+                new string('e', 64))).ToList();
             return Task.FromResult(new ProviderBatchResult<MarketQuoteResult>(quotes, []));
         }
     }

--- a/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
+++ b/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
@@ -64,6 +64,48 @@ public class MarketDataProvidersTests
     }
 
     [Fact]
+    public async Task Marketstack_ShouldUseV1EodAndApplyTheConfiguredPriceMultiplier()
+    {
+        const string payload = """
+            {
+              "pagination": { "limit": 100, "offset": 0, "count": 1, "total": 1 },
+              "data": [{
+                "symbol": "BARC.XLON",
+                "exchange": "XLON",
+                "date": "2026-08-10T00:00:00+0000",
+                "close": 514.20
+              }]
+            }
+            """;
+        Uri? requestedUri = null;
+        var provider = new MarketstackMarketQuoteProvider(
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return JsonResponse(payload);
+            }))
+            {
+                BaseAddress = new Uri("https://api.marketstack.com/")
+            },
+            Options.Create(new MarketDataOptions { MarketstackApiKey = "test-key" }),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.XLON", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        var quote = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal("/v1/eod/latest", requestedUri!.AbsolutePath);
+        Assert.Contains("symbols=BARC.XLON", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Equal(5.1420m, quote.Price);
+        Assert.Equal("GBP", quote.Currency);
+        Assert.Equal("XLON", quote.Exchange);
+        Assert.Equal("XLON", quote.Mic);
+        Assert.True(quote.IsFallback);
+    }
+
+    [Fact]
     public async Task Ecb_ShouldReturnCurrencyUnitsPerEur()
     {
         const string csv = """


### PR DESCRIPTION
## What changed

- use Marketstack's working `v1/eod/latest` endpoint
- keep trying lower-priority quote providers when a provider returns a quote old enough to be `BLOCKED`
- retain blocked snapshots for audit without incorrectly reporting that no provider returned data
- add provider and orchestration tests for the `BARC.XLON`/GBP price multiplier flow

## Why

Marketstack identifies Barclays on the London Stock Exchange as `BARC.XLON`. Its v2 EOD endpoint rejects that symbol, while v1 returns an EOD record. The available Marketstack record is currently stale, and the previous orchestration stopped after accepting it, preventing the configured Yahoo fallback from returning the current `BARC.L` quote.

## Impact

Non-US instruments can use explicit Marketstack mappings and still fall through to Yahoo when Marketstack data is blocked by freshness rules. London prices expressed in pence can continue to use an explicit `0.01` multiplier when the instrument currency is GBP.

## Validation

- `dotnet test backend/CostTracker.sln`
- 74 tests passed
- production preflight confirmed `BARC.XLON` in Marketstack and a current `BARC.L` quote through Yahoo