### PR TITLE
Add Alpha Vantage and EODHD for London quotes

### DIFF
--- a/backend/CostTracker.Api/appsettings.json
+++ b/backend/CostTracker.Api/appsettings.json
@@ -19,6 +19,7 @@
     "TwelveDataApiKey": "",
     "MarketstackApiKey": "",
     "AlphaVantageApiKey": "",
+    "EodhdApiKey": "",
     "EnablePublicTestQuotes": false,
     "EnableBackgroundRefresh": false,
     "RefreshOnStartup": true,

--- a/backend/CostTracker.Api/appsettings.json
+++ b/backend/CostTracker.Api/appsettings.json
@@ -18,6 +18,7 @@
   "MarketData": {
     "TwelveDataApiKey": "",
     "MarketstackApiKey": "",
+    "AlphaVantageApiKey": "",
     "EnablePublicTestQuotes": false,
     "EnableBackgroundRefresh": false,
     "RefreshOnStartup": true,

--- a/backend/CostTracker.Application/Investments/MarketData/MarketDataModels.cs
+++ b/backend/CostTracker.Application/Investments/MarketData/MarketDataModels.cs
@@ -4,6 +4,7 @@ public static class MarketDataProviderCodes
 {
     public const string TwelveData = "TWELVE_DATA";
     public const string Marketstack = "MARKETSTACK";
+    public const string AlphaVantage = "ALPHA_VANTAGE";
     public const string YahooTest = "YAHOO_TEST";
     public const string Ecb = "ECB";
     public const string BcbPtax = "BCB_PTAX";

--- a/backend/CostTracker.Application/Investments/MarketData/MarketDataModels.cs
+++ b/backend/CostTracker.Application/Investments/MarketData/MarketDataModels.cs
@@ -5,6 +5,7 @@ public static class MarketDataProviderCodes
     public const string TwelveData = "TWELVE_DATA";
     public const string Marketstack = "MARKETSTACK";
     public const string AlphaVantage = "ALPHA_VANTAGE";
+    public const string Eodhd = "EODHD";
     public const string YahooTest = "YAHOO_TEST";
     public const string Ecb = "ECB";
     public const string BcbPtax = "BCB_PTAX";

--- a/backend/CostTracker.Application/Options/MarketDataOptions.cs
+++ b/backend/CostTracker.Application/Options/MarketDataOptions.cs
@@ -4,6 +4,7 @@ public sealed class MarketDataOptions
 {
     public string TwelveDataApiKey { get; set; } = string.Empty;
     public string MarketstackApiKey { get; set; } = string.Empty;
+    public string AlphaVantageApiKey { get; set; } = string.Empty;
     public bool EnablePublicTestQuotes { get; set; }
     public bool EnableBackgroundRefresh { get; set; }
     public bool RefreshOnStartup { get; set; } = true;

--- a/backend/CostTracker.Application/Options/MarketDataOptions.cs
+++ b/backend/CostTracker.Application/Options/MarketDataOptions.cs
@@ -5,6 +5,7 @@ public sealed class MarketDataOptions
     public string TwelveDataApiKey { get; set; } = string.Empty;
     public string MarketstackApiKey { get; set; } = string.Empty;
     public string AlphaVantageApiKey { get; set; } = string.Empty;
+    public string EodhdApiKey { get; set; } = string.Empty;
     public bool EnablePublicTestQuotes { get; set; }
     public bool EnableBackgroundRefresh { get; set; }
     public bool RefreshOnStartup { get; set; } = true;

--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -509,18 +509,24 @@ public sealed class InvestmentMarketDataService(
                     string.Equals(item.ProviderCode, provider.ProviderCode, StringComparison.OrdinalIgnoreCase));
                 if (explicitMapping is { IsEnabled: false })
                     continue;
+                var isLondonInstrument = IsLondonExchange(explicitMapping?.Mic ?? instrument.Mic);
                 // The configured Twelve Data and Marketstack plans do not provide
-                // current London quotes. Route London instruments to Yahoo until a
-                // dedicated LSE provider is added.
-                if (IsLondonExchange(explicitMapping?.Mic ?? instrument.Mic) &&
+                // current London quotes. Alpha Vantage is the primary LSE provider.
+                if (isLondonInstrument &&
                     provider.ProviderCode is MarketDataProviderCodes.TwelveData or MarketDataProviderCodes.Marketstack)
                 {
                     continue;
                 }
+                if (!isLondonInstrument && provider.ProviderCode == MarketDataProviderCodes.AlphaVantage)
+                    continue;
                 // Marketstack EOD rows do not identify the quote currency/unit.
                 // Requiring an explicit mapping prevents an LSE pence quote from
                 // being labelled as GBP and overstating the position by 100x.
                 if (provider.ProviderCode == MarketDataProviderCodes.Marketstack && explicitMapping is null)
+                    continue;
+                // Alpha Vantage daily rows also omit the quote currency/unit. An
+                // explicit mapping is required to safely convert GBX into GBP.
+                if (provider.ProviderCode == MarketDataProviderCodes.AlphaVantage && explicitMapping is null)
                     continue;
                 var symbol = explicitMapping?.ProviderSymbol ?? ResolveProviderSymbol(
                     provider.ProviderCode,

--- a/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
+++ b/backend/CostTracker.Application/Services/InvestmentMarketDataService.cs
@@ -511,22 +511,25 @@ public sealed class InvestmentMarketDataService(
                     continue;
                 var isLondonInstrument = IsLondonExchange(explicitMapping?.Mic ?? instrument.Mic);
                 // The configured Twelve Data and Marketstack plans do not provide
-                // current London quotes. Alpha Vantage is the primary LSE provider.
+                // current London quotes. Alpha Vantage and EODHD cover the LSE.
                 if (isLondonInstrument &&
                     provider.ProviderCode is MarketDataProviderCodes.TwelveData or MarketDataProviderCodes.Marketstack)
                 {
                     continue;
                 }
-                if (!isLondonInstrument && provider.ProviderCode == MarketDataProviderCodes.AlphaVantage)
+                if (!isLondonInstrument &&
+                    provider.ProviderCode is MarketDataProviderCodes.AlphaVantage or MarketDataProviderCodes.Eodhd)
                     continue;
                 // Marketstack EOD rows do not identify the quote currency/unit.
                 // Requiring an explicit mapping prevents an LSE pence quote from
                 // being labelled as GBP and overstating the position by 100x.
                 if (provider.ProviderCode == MarketDataProviderCodes.Marketstack && explicitMapping is null)
                     continue;
-                // Alpha Vantage daily rows also omit the quote currency/unit. An
-                // explicit mapping is required to safely convert GBX into GBP.
-                if (provider.ProviderCode == MarketDataProviderCodes.AlphaVantage && explicitMapping is null)
+                // Alpha Vantage and EODHD daily rows also omit the quote
+                // currency/unit. An explicit mapping is required to safely
+                // convert GBX into GBP.
+                if (provider.ProviderCode is MarketDataProviderCodes.AlphaVantage or MarketDataProviderCodes.Eodhd &&
+                    explicitMapping is null)
                     continue;
                 var symbol = explicitMapping?.ProviderSymbol ?? ResolveProviderSymbol(
                     provider.ProviderCode,

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/AlphaVantageMarketQuoteProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/AlphaVantageMarketQuoteProvider.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Text.Json;
+using CostTracker.Application.Investments.MarketData;
+using CostTracker.Application.Options;
+using Microsoft.Extensions.Options;
+
+namespace CostTracker.Infrastructure.Investments.MarketData;
+
+public sealed class AlphaVantageMarketQuoteProvider(
+    HttpClient httpClient,
+    IOptions<MarketDataOptions> options,
+    TimeProvider timeProvider) : IMarketQuoteProvider
+{
+    public string ProviderCode => MarketDataProviderCodes.AlphaVantage;
+
+    public async Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+        IReadOnlyList<MarketQuoteRequest> requests,
+        CancellationToken cancellationToken)
+    {
+        if (requests.Count == 0)
+            return ProviderBatchResult<MarketQuoteResult>.Empty;
+
+        if (string.IsNullOrWhiteSpace(options.Value.AlphaVantageApiKey))
+        {
+            return new([], requests.Select(request => new ProviderFailure(
+                ProviderCode,
+                request.ProviderSymbol,
+                "Alpha Vantage API key is not configured.",
+                false)).ToList());
+        }
+
+        var quotes = new List<MarketQuoteResult>(requests.Count);
+        var failures = new List<ProviderFailure>();
+
+        for (var index = 0; index < requests.Count; index++)
+        {
+            var request = requests[index];
+            if (index > 0)
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+
+            try
+            {
+                var uri = "query?function=TIME_SERIES_DAILY" +
+                          $"&symbol={Uri.EscapeDataString(request.ProviderSymbol)}" +
+                          "&outputsize=compact" +
+                          $"&apikey={Uri.EscapeDataString(options.Value.AlphaVantageApiKey)}";
+                using var response = await httpClient.GetAsync(uri, cancellationToken);
+                var payload = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    failures.Add(Failure(
+                        request,
+                        $"HTTP {(int)response.StatusCode} from Alpha Vantage.",
+                        IsTransient(response.StatusCode)));
+                    continue;
+                }
+
+                using var document = JsonDocument.Parse(payload);
+                var root = document.RootElement;
+                var providerMessage = MarketDataParsing.GetString(root, "Error Message", "Information", "Note");
+                if (!string.IsNullOrWhiteSpace(providerMessage))
+                {
+                    failures.Add(Failure(request, providerMessage, root.TryGetProperty("Information", out _) || root.TryGetProperty("Note", out _)));
+                    continue;
+                }
+
+                if (!root.TryGetProperty("Time Series (Daily)", out var series) ||
+                    series.ValueKind != JsonValueKind.Object)
+                {
+                    failures.Add(Failure(request, "Alpha Vantage response has no daily time series.", false));
+                    continue;
+                }
+
+                if (request.PriceMultiplier <= 0m)
+                {
+                    failures.Add(Failure(request, "The configured price multiplier must be positive.", false));
+                    continue;
+                }
+
+                DateOnly latestDate = default;
+                decimal latestClose = 0m;
+                foreach (var day in series.EnumerateObject())
+                {
+                    if (!MarketDataParsing.TryParseDate(day.Name, out var date) ||
+                        !MarketDataParsing.TryGetDecimal(day.Value, "4. close", out var close) ||
+                        close <= 0m ||
+                        date <= latestDate)
+                    {
+                        continue;
+                    }
+
+                    latestDate = date;
+                    latestClose = close;
+                }
+
+                if (latestDate == default || latestClose <= 0m)
+                {
+                    failures.Add(Failure(request, "Alpha Vantage response has no positive closing price.", false));
+                    continue;
+                }
+
+                var symbol = request.ProviderSymbol;
+                if (root.TryGetProperty("Meta Data", out var metadata))
+                {
+                    symbol = MarketDataParsing.GetString(metadata, "2. Symbol") ?? symbol;
+                    if (!string.Equals(symbol, request.ProviderSymbol, StringComparison.OrdinalIgnoreCase))
+                    {
+                        failures.Add(Failure(
+                            request,
+                            $"Symbol mismatch: expected {request.ProviderSymbol}, received {symbol}.",
+                            false));
+                        continue;
+                    }
+                }
+
+                quotes.Add(new MarketQuoteResult(
+                    request.InstrumentId,
+                    ProviderCode,
+                    symbol,
+                    request.Exchange,
+                    request.Mic,
+                    latestClose * request.PriceMultiplier,
+                    request.ExpectedCurrency.Trim().ToUpperInvariant(),
+                    "EOD_CLOSE",
+                    latestDate,
+                    timeProvider.GetUtcNow(),
+                    false,
+                    MarketDataParsing.Sha256(payload)));
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested &&
+                                       ex is HttpRequestException or TaskCanceledException or JsonException)
+            {
+                failures.Add(Failure(request, ex.Message, true));
+            }
+        }
+
+        return new(quotes, failures);
+    }
+
+    private ProviderFailure Failure(MarketQuoteRequest request, string message, bool transient)
+        => new(ProviderCode, request.ProviderSymbol, message, transient);
+
+    private static bool IsTransient(HttpStatusCode statusCode)
+        => statusCode == HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
+}

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/EodhdMarketQuoteProvider.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/EodhdMarketQuoteProvider.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using System.Text.Json;
+using CostTracker.Application.Investments.MarketData;
+using CostTracker.Application.Options;
+using Microsoft.Extensions.Options;
+
+namespace CostTracker.Infrastructure.Investments.MarketData;
+
+public sealed class EodhdMarketQuoteProvider(
+    HttpClient httpClient,
+    IOptions<MarketDataOptions> options,
+    TimeProvider timeProvider) : IMarketQuoteProvider
+{
+    public string ProviderCode => MarketDataProviderCodes.Eodhd;
+
+    public async Task<ProviderBatchResult<MarketQuoteResult>> GetLatestQuotesAsync(
+        IReadOnlyList<MarketQuoteRequest> requests,
+        CancellationToken cancellationToken)
+    {
+        if (requests.Count == 0)
+            return ProviderBatchResult<MarketQuoteResult>.Empty;
+
+        if (string.IsNullOrWhiteSpace(options.Value.EodhdApiKey))
+        {
+            return new([], requests.Select(request => new ProviderFailure(
+                ProviderCode,
+                request.ProviderSymbol,
+                "EODHD API key is not configured.",
+                false)).ToList());
+        }
+
+        var quotes = new List<MarketQuoteResult>(requests.Count);
+        var failures = new List<ProviderFailure>();
+        var from = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime).AddDays(-30);
+
+        foreach (var request in requests)
+        {
+            try
+            {
+                var uri = $"eod/{Uri.EscapeDataString(request.ProviderSymbol)}" +
+                          $"?api_token={Uri.EscapeDataString(options.Value.EodhdApiKey)}" +
+                          "&fmt=json" +
+                          $"&from={from:yyyy-MM-dd}";
+                using var response = await httpClient.GetAsync(uri, cancellationToken);
+                var payload = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    failures.Add(Failure(
+                        request,
+                        $"HTTP {(int)response.StatusCode} from EODHD.",
+                        IsTransient(response.StatusCode)));
+                    continue;
+                }
+
+                using var document = JsonDocument.Parse(payload);
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Array)
+                {
+                    var message = root.ValueKind == JsonValueKind.Object
+                        ? MarketDataParsing.GetString(root, "message", "error")
+                        : null;
+                    failures.Add(Failure(request, message ?? "EODHD response has no data array.", false));
+                    continue;
+                }
+
+                if (request.PriceMultiplier <= 0m)
+                {
+                    failures.Add(Failure(request, "The configured price multiplier must be positive.", false));
+                    continue;
+                }
+
+                DateOnly latestDate = default;
+                decimal latestClose = 0m;
+                foreach (var row in root.EnumerateArray())
+                {
+                    if (row.ValueKind != JsonValueKind.Object ||
+                        !MarketDataParsing.TryParseDate(MarketDataParsing.GetString(row, "date"), out var date) ||
+                        !MarketDataParsing.TryGetDecimal(row, "close", out var close) ||
+                        close <= 0m ||
+                        date <= latestDate)
+                    {
+                        continue;
+                    }
+
+                    latestDate = date;
+                    latestClose = close;
+                }
+
+                if (latestDate == default || latestClose <= 0m)
+                {
+                    failures.Add(Failure(request, "EODHD response has no positive closing price.", false));
+                    continue;
+                }
+
+                quotes.Add(new MarketQuoteResult(
+                    request.InstrumentId,
+                    ProviderCode,
+                    request.ProviderSymbol,
+                    request.Exchange,
+                    request.Mic,
+                    latestClose * request.PriceMultiplier,
+                    request.ExpectedCurrency.Trim().ToUpperInvariant(),
+                    "EOD_CLOSE",
+                    latestDate,
+                    timeProvider.GetUtcNow(),
+                    true,
+                    MarketDataParsing.Sha256(payload)));
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested &&
+                                       ex is HttpRequestException or TaskCanceledException or JsonException)
+            {
+                failures.Add(Failure(request, ex.Message, true));
+            }
+        }
+
+        return new(quotes, failures);
+    }
+
+    private ProviderFailure Failure(MarketQuoteRequest request, string message, bool transient)
+        => new(ProviderCode, request.ProviderSymbol, message, transient);
+
+    private static bool IsTransient(HttpStatusCode statusCode)
+        => statusCode == HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
+}

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/MarketDataDependencyInjectionExtensions.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/MarketDataDependencyInjectionExtensions.cs
@@ -32,6 +32,7 @@ public static class MarketDataDependencyInjectionExtensions
         AddProviderClient<TwelveDataMarketQuoteProvider>(services, "https://api.twelvedata.com/");
         AddProviderClient<MarketstackMarketQuoteProvider>(services, "https://api.marketstack.com/");
         AddProviderClient<AlphaVantageMarketQuoteProvider>(services, "https://www.alphavantage.co/");
+        AddProviderClient<EodhdMarketQuoteProvider>(services, "https://eodhd.com/api/");
         AddProviderClient<YahooTestMarketQuoteProvider>(services, "https://query1.finance.yahoo.com/");
         AddProviderClient<EcbExchangeRateProvider>(services, "https://data-api.ecb.europa.eu/");
         AddProviderClient<BcbPtaxExchangeRateProvider>(
@@ -41,6 +42,7 @@ public static class MarketDataDependencyInjectionExtensions
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<TwelveDataMarketQuoteProvider>());
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<MarketstackMarketQuoteProvider>());
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<AlphaVantageMarketQuoteProvider>());
+        services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<EodhdMarketQuoteProvider>());
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<YahooTestMarketQuoteProvider>());
         services.AddTransient<IExchangeRateProvider>(provider => provider.GetRequiredService<EcbExchangeRateProvider>());
         services.AddTransient<IExchangeRateProvider>(provider => provider.GetRequiredService<BcbPtaxExchangeRateProvider>());

--- a/backend/CostTracker.Infrastructure/Investments/MarketData/MarketDataDependencyInjectionExtensions.cs
+++ b/backend/CostTracker.Infrastructure/Investments/MarketData/MarketDataDependencyInjectionExtensions.cs
@@ -31,6 +31,7 @@ public static class MarketDataDependencyInjectionExtensions
 
         AddProviderClient<TwelveDataMarketQuoteProvider>(services, "https://api.twelvedata.com/");
         AddProviderClient<MarketstackMarketQuoteProvider>(services, "https://api.marketstack.com/");
+        AddProviderClient<AlphaVantageMarketQuoteProvider>(services, "https://www.alphavantage.co/");
         AddProviderClient<YahooTestMarketQuoteProvider>(services, "https://query1.finance.yahoo.com/");
         AddProviderClient<EcbExchangeRateProvider>(services, "https://data-api.ecb.europa.eu/");
         AddProviderClient<BcbPtaxExchangeRateProvider>(
@@ -39,6 +40,7 @@ public static class MarketDataDependencyInjectionExtensions
 
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<TwelveDataMarketQuoteProvider>());
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<MarketstackMarketQuoteProvider>());
+        services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<AlphaVantageMarketQuoteProvider>());
         services.AddTransient<IMarketQuoteProvider>(provider => provider.GetRequiredService<YahooTestMarketQuoteProvider>());
         services.AddTransient<IExchangeRateProvider>(provider => provider.GetRequiredService<EcbExchangeRateProvider>());
         services.AddTransient<IExchangeRateProvider>(provider => provider.GetRequiredService<BcbPtaxExchangeRateProvider>());

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -93,16 +93,19 @@ public sealed class InvestmentMarketDataServiceTests
             CreateMapping(lloyds, MarketDataProviderCodes.TwelveData, "LLOY", isEnabled: false),
             CreateMapping(lloyds, MarketDataProviderCodes.Marketstack, "LLOY.XLON"),
             CreateMapping(barc, MarketDataProviderCodes.AlphaVantage, "BARC.LON"),
-            CreateMapping(lloyds, MarketDataProviderCodes.AlphaVantage, "LLOY.LON"));
+            CreateMapping(lloyds, MarketDataProviderCodes.AlphaVantage, "LLOY.LON"),
+            CreateMapping(barc, MarketDataProviderCodes.Eodhd, "BARC.LSE"),
+            CreateMapping(lloyds, MarketDataProviderCodes.Eodhd, "LLOY.LSE"));
         await dbContext.SaveChangesAsync();
 
         var twelveData = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.TwelveData);
         var marketstack = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.Marketstack);
         var alphaVantage = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.AlphaVantage);
+        var eodhd = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.Eodhd);
         var yahoo = new CapturingQuoteProvider(FixedNow);
         var service = new InvestmentMarketDataService(
             dbContext,
-            [twelveData, marketstack, alphaVantage, yahoo],
+            [twelveData, marketstack, alphaVantage, eodhd, yahoo],
             [new CapturingExchangeRateProvider(FixedNow)],
             new PortfolioProjectionService(),
             Options.Create(new MarketDataOptions
@@ -119,7 +122,67 @@ public sealed class InvestmentMarketDataServiceTests
         Assert.Equal(
             ["BARC.LON", "LLOY.LON"],
             alphaVantage.Requests.Select(request => request.ProviderSymbol).Order().ToArray());
+        Assert.Empty(eodhd.Requests);
         Assert.Empty(yahoo.Requests);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldUseEodhdBeforeYahooWhenAlphaVantageIsBlocked()
+    {
+        var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
+            .UseInMemoryDatabase($"market-eodhd-fallback-{Guid.NewGuid():N}")
+            .Options;
+        await using var dbContext = new CostTrackerDbContext(options);
+        var portfolio = InvestmentPortfolio.Create(FixedNow);
+        var instrument = CreateQuotedInstrument(portfolio, "BARC", "XLON");
+        portfolio.Instruments.Add(instrument);
+        dbContext.InvestmentPortfolios.Add(portfolio);
+        dbContext.MarketInstrumentMappings.AddRange(
+            CreateMapping(instrument, MarketDataProviderCodes.AlphaVantage, "BARC.LON"),
+            CreateMapping(instrument, MarketDataProviderCodes.Eodhd, "BARC.LSE"));
+        await dbContext.SaveChangesAsync();
+
+        var alphaVantage = new FixedQuoteProvider(
+            MarketDataProviderCodes.AlphaVantage,
+            FixedNow,
+            new DateOnly(2023, 10, 18),
+            1.5164m);
+        var eodhd = new FixedQuoteProvider(
+            MarketDataProviderCodes.Eodhd,
+            FixedNow,
+            new DateOnly(2026, 8, 10),
+            5.142m);
+        var yahoo = new FixedQuoteProvider(
+            MarketDataProviderCodes.YahooTest,
+            FixedNow,
+            new DateOnly(2026, 8, 10),
+            5.142m);
+        var service = new InvestmentMarketDataService(
+            dbContext,
+            [alphaVantage, eodhd, yahoo],
+            [new CapturingExchangeRateProvider(FixedNow)],
+            new PortfolioProjectionService(),
+            Options.Create(new MarketDataOptions
+            {
+                RefreshTimeZone = "Europe/Lisbon",
+                EnablePublicTestQuotes = true,
+                QuoteWarningSessions = 1,
+                QuoteBlockingSessions = 2
+            }),
+            new FixedTimeProvider(FixedNow));
+
+        var status = await service.RefreshAsync();
+
+        Assert.Equal(DataFreshnessCodes.Fresh, status.Freshness);
+        Assert.Equal(1, alphaVantage.CallCount);
+        Assert.Equal(1, eodhd.CallCount);
+        Assert.Equal(0, yahoo.CallCount);
+        var latest = await dbContext.MarketQuoteSnapshots
+            .Where(item => item.InstrumentId == instrument.Id)
+            .OrderByDescending(item => item.AsOf)
+            .FirstAsync();
+        Assert.Equal(MarketDataProviderCodes.Eodhd, latest.ProviderCode);
+        Assert.Equal(5.142m, latest.Price);
     }
 
     [Fact]

--- a/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
+++ b/backend/CostTracker.Tests/Investments/InvestmentMarketDataServiceTests.cs
@@ -75,7 +75,7 @@ public sealed class InvestmentMarketDataServiceTests
     }
 
     [Fact]
-    public async Task Refresh_ShouldUseOnlyYahooForLondonInstruments()
+    public async Task Refresh_ShouldUseAlphaVantageForLondonAndTwelveDataForUs()
     {
         var options = new DbContextOptionsBuilder<CostTrackerDbContext>()
             .UseInMemoryDatabase($"market-london-provider-{Guid.NewGuid():N}")
@@ -91,15 +91,18 @@ public sealed class InvestmentMarketDataServiceTests
         dbContext.MarketInstrumentMappings.AddRange(
             CreateMapping(barc, MarketDataProviderCodes.TwelveData, "BARC"),
             CreateMapping(lloyds, MarketDataProviderCodes.TwelveData, "LLOY", isEnabled: false),
-            CreateMapping(lloyds, MarketDataProviderCodes.Marketstack, "LLOY.XLON"));
+            CreateMapping(lloyds, MarketDataProviderCodes.Marketstack, "LLOY.XLON"),
+            CreateMapping(barc, MarketDataProviderCodes.AlphaVantage, "BARC.LON"),
+            CreateMapping(lloyds, MarketDataProviderCodes.AlphaVantage, "LLOY.LON"));
         await dbContext.SaveChangesAsync();
 
         var twelveData = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.TwelveData);
         var marketstack = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.Marketstack);
+        var alphaVantage = new CapturingQuoteProvider(FixedNow, MarketDataProviderCodes.AlphaVantage);
         var yahoo = new CapturingQuoteProvider(FixedNow);
         var service = new InvestmentMarketDataService(
             dbContext,
-            [twelveData, marketstack, yahoo],
+            [twelveData, marketstack, alphaVantage, yahoo],
             [new CapturingExchangeRateProvider(FixedNow)],
             new PortfolioProjectionService(),
             Options.Create(new MarketDataOptions
@@ -114,8 +117,9 @@ public sealed class InvestmentMarketDataServiceTests
         Assert.Equal(["O"], twelveData.Requests.Select(request => request.ProviderSymbol).ToArray());
         Assert.Empty(marketstack.Requests);
         Assert.Equal(
-            ["BARC.L", "LLOY.L"],
-            yahoo.Requests.Select(request => request.ProviderSymbol).Order().ToArray());
+            ["BARC.LON", "LLOY.LON"],
+            alphaVantage.Requests.Select(request => request.ProviderSymbol).Order().ToArray());
+        Assert.Empty(yahoo.Requests);
     }
 
     [Fact]
@@ -201,10 +205,12 @@ public sealed class InvestmentMarketDataServiceTests
         var instrument = CreateQuotedInstrument(portfolio, "BARC", "XLON");
         portfolio.Instruments.Add(instrument);
         dbContext.InvestmentPortfolios.Add(portfolio);
+        dbContext.MarketInstrumentMappings.Add(
+            CreateMapping(instrument, MarketDataProviderCodes.AlphaVantage, "BARC.LON"));
         await dbContext.SaveChangesAsync();
 
         var blockedProvider = new FixedQuoteProvider(
-            "BLOCKED_PRIMARY",
+            MarketDataProviderCodes.AlphaVantage,
             FixedNow,
             new DateOnly(2023, 10, 18),
             1.5164m);

--- a/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
+++ b/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
@@ -193,6 +193,64 @@ public class MarketDataProvidersTests
     }
 
     [Fact]
+    public async Task Eodhd_ShouldUseLatestDailyCloseAndApplyTheConfiguredPriceMultiplier()
+    {
+        const string payload = """
+            [
+              { "date": "2026-08-17", "close": 515.4 },
+              { "date": "2026-08-18", "close": 503.6 }
+            ]
+            """;
+        Uri? requestedUri = null;
+        var provider = new EodhdMarketQuoteProvider(
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return JsonResponse(payload);
+            }))
+            {
+                BaseAddress = new Uri("https://eodhd.com/api/")
+            },
+            Options.Create(new MarketDataOptions { EodhdApiKey = "test-key" }),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.LSE", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        var quote = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal("/api/eod/BARC.LSE", requestedUri!.AbsolutePath);
+        Assert.Contains("api_token=test-key", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Contains("fmt=json", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Contains("from=2026-07-12", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Equal(MarketDataProviderCodes.Eodhd, quote.Provider);
+        Assert.Equal(5.036m, quote.Price);
+        Assert.Equal("GBP", quote.Currency);
+        Assert.Equal("XLON", quote.Mic);
+        Assert.Equal(new DateOnly(2026, 8, 18), quote.AsOf);
+        Assert.True(quote.IsFallback);
+    }
+
+    [Fact]
+    public async Task Eodhd_ShouldNotCallNetworkWithoutApiKey()
+    {
+        var handler = new StubHttpMessageHandler(_ => throw new InvalidOperationException("Network should not be called."));
+        var provider = new EodhdMarketQuoteProvider(
+            new HttpClient(handler) { BaseAddress = new Uri("https://eodhd.com/api/") },
+            Options.Create(new MarketDataOptions()),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.LSE", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        Assert.Contains(result.Failures, failure => failure.Message.Contains("not configured", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
     public async Task Ecb_ShouldReturnCurrencyUnitsPerEur()
     {
         const string csv = """

--- a/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
+++ b/backend/CostTracker.Tests/Investments/MarketDataProvidersTests.cs
@@ -106,6 +106,93 @@ public class MarketDataProvidersTests
     }
 
     [Fact]
+    public async Task AlphaVantage_ShouldUseLatestDailyCloseAndApplyTheConfiguredPriceMultiplier()
+    {
+        const string payload = """
+            {
+              "Meta Data": {
+                "1. Information": "Daily Prices (open, high, low, close) and Volumes",
+                "2. Symbol": "BARC.LON",
+                "3. Last Refreshed": "2026-08-18"
+              },
+              "Time Series (Daily)": {
+                "2026-08-17": { "4. close": "515.4000" },
+                "2026-08-18": { "4. close": "503.6000" }
+              }
+            }
+            """;
+        Uri? requestedUri = null;
+        var provider = new AlphaVantageMarketQuoteProvider(
+            new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return JsonResponse(payload);
+            }))
+            {
+                BaseAddress = new Uri("https://www.alphavantage.co/")
+            },
+            Options.Create(new MarketDataOptions { AlphaVantageApiKey = "test-key" }),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.LON", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        var quote = Assert.Single(result.Items);
+        Assert.Empty(result.Failures);
+        Assert.Equal("/query", requestedUri!.AbsolutePath);
+        Assert.Contains("function=TIME_SERIES_DAILY", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Contains("symbol=BARC.LON", requestedUri.Query, StringComparison.Ordinal);
+        Assert.Equal(MarketDataProviderCodes.AlphaVantage, quote.Provider);
+        Assert.Equal(5.0360m, quote.Price);
+        Assert.Equal("GBP", quote.Currency);
+        Assert.Equal("XLON", quote.Mic);
+        Assert.Equal(new DateOnly(2026, 8, 18), quote.AsOf);
+        Assert.False(quote.IsFallback);
+    }
+
+    [Fact]
+    public async Task AlphaVantage_ShouldNotCallNetworkWithoutApiKey()
+    {
+        var handler = new StubHttpMessageHandler(_ => throw new InvalidOperationException("Network should not be called."));
+        var provider = new AlphaVantageMarketQuoteProvider(
+            new HttpClient(handler) { BaseAddress = new Uri("https://www.alphavantage.co/") },
+            Options.Create(new MarketDataOptions()),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.LON", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        Assert.Contains(result.Failures, failure => failure.Message.Contains("not configured", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task AlphaVantage_ShouldTreatRateLimitInformationAsTransientFailure()
+    {
+        const string payload = """
+            { "Information": "Please spread out free API requests more sparingly." }
+            """;
+        var provider = new AlphaVantageMarketQuoteProvider(
+            new HttpClient(new StubHttpMessageHandler(_ => JsonResponse(payload)))
+            {
+                BaseAddress = new Uri("https://www.alphavantage.co/")
+            },
+            Options.Create(new MarketDataOptions { AlphaVantageApiKey = "test-key" }),
+            new FixedTimeProvider(FixedNow));
+
+        var result = await provider.GetLatestQuotesAsync(
+            [new MarketQuoteRequest(Guid.NewGuid(), "BARC.LON", "LSE", "XLON", "GBP", 0.01m)],
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        var failure = Assert.Single(result.Failures);
+        Assert.True(failure.IsTransient);
+    }
+
+    [Fact]
     public async Task Ecb_ShouldReturnCurrencyUnitsPerEur()
     {
         const string csv = """

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -25,11 +25,12 @@ AUTH_USERNAME=admin
 AUTH_PASSWORD_HASH=CHANGE_ME_HASH
 ANTHROPIC_API_KEY=CHANGE_ME_ANTHROPIC_API_KEY
 
-# Investment market data. Twelve Data/Marketstack cover US assets; Alpha Vantage covers LSE.
+# Investment market data. Twelve Data/Marketstack cover US assets; Alpha Vantage/EODHD cover LSE.
 # The keys may stay empty while testing with manual quotes; ECB/BCB FX needs no key.
 TWELVE_DATA_API_KEY=
 MARKETSTACK_API_KEY=
 ALPHA_VANTAGE_API_KEY=
+EODHD_API_KEY=
 MARKET_DATA_ENABLE_PUBLIC_TEST_QUOTES=true
 MARKET_DATA_ENABLE_BACKGROUND_REFRESH=true
 MARKET_DATA_REFRESH_ON_STARTUP=true

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -25,10 +25,11 @@ AUTH_USERNAME=admin
 AUTH_PASSWORD_HASH=CHANGE_ME_HASH
 ANTHROPIC_API_KEY=CHANGE_ME_ANTHROPIC_API_KEY
 
-# Investment market data. Twelve Data is primary and Marketstack is the EOD fallback.
+# Investment market data. Twelve Data/Marketstack cover US assets; Alpha Vantage covers LSE.
 # The keys may stay empty while testing with manual quotes; ECB/BCB FX needs no key.
 TWELVE_DATA_API_KEY=
 MARKETSTACK_API_KEY=
+ALPHA_VANTAGE_API_KEY=
 MARKET_DATA_ENABLE_PUBLIC_TEST_QUOTES=true
 MARKET_DATA_ENABLE_BACKGROUND_REFRESH=true
 MARKET_DATA_REFRESH_ON_STARTUP=true

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -31,6 +31,7 @@ services:
       MarketData__TwelveDataApiKey: ${TWELVE_DATA_API_KEY:-}
       MarketData__MarketstackApiKey: ${MARKETSTACK_API_KEY:-}
       MarketData__AlphaVantageApiKey: ${ALPHA_VANTAGE_API_KEY:-}
+      MarketData__EodhdApiKey: ${EODHD_API_KEY:-}
       MarketData__EnablePublicTestQuotes: ${MARKET_DATA_ENABLE_PUBLIC_TEST_QUOTES:-true}
       MarketData__EnableBackgroundRefresh: ${MARKET_DATA_ENABLE_BACKGROUND_REFRESH:-true}
       MarketData__RefreshOnStartup: ${MARKET_DATA_REFRESH_ON_STARTUP:-true}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -30,6 +30,7 @@ services:
       Anthropic__ApiKey: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY is required}
       MarketData__TwelveDataApiKey: ${TWELVE_DATA_API_KEY:-}
       MarketData__MarketstackApiKey: ${MARKETSTACK_API_KEY:-}
+      MarketData__AlphaVantageApiKey: ${ALPHA_VANTAGE_API_KEY:-}
       MarketData__EnablePublicTestQuotes: ${MARKET_DATA_ENABLE_PUBLIC_TEST_QUOTES:-true}
       MarketData__EnableBackgroundRefresh: ${MARKET_DATA_ENABLE_BACKGROUND_REFRESH:-true}
       MarketData__RefreshOnStartup: ${MARKET_DATA_REFRESH_ON_STARTUP:-true}

--- a/docs/research/free-barc-market-data-providers.md
+++ b/docs/research/free-barc-market-data-providers.md
@@ -1,27 +1,27 @@
 # Provedores gratuitos de EOD para Barclays na LSE
 
-Pesquisa verificada em **19 de agosto de 2026**, usando fontes oficiais dos provedores e da London Stock Exchange. Preços, franquias e cobertura podem mudar; o preflight com uma chave própria continua sendo obrigatório.
+Pesquisa verificada em **19 de agosto de 2026**, usando fontes oficiais dos provedores, chamadas reais das APIs e a London Stock Exchange. Preços, franquias e cobertura podem mudar; novos símbolos continuam exigindo preflight.
 
 ## Conclusão
 
-A alternativa gratuita mais plausível ao Yahoo Finance para `BARC` é o **Alpha Vantage**. A documentação oficial inclui ações da London Stock Exchange no endpoint diário global, usa o sufixo `.LON` e permite as 100 observações mais recentes com chave gratuita. A franquia gratuita atual é de **25 chamadas por dia**, suficiente para uma consulta EOD diária de `BARC`. O fornecedor também declara que licencia dados oficialmente da LSE. [Documentação do `TIME_SERIES_DAILY`](https://www.alphavantage.co/documentation/#daily), [limite gratuito](https://www.alphavantage.co/support/) e [origens/cobertura](https://www.alphavantage.co/stock_api_landing/)
+A alternativa gratuita validada para `BARC` é o **Alpha Vantage**. A documentação oficial inclui ações da London Stock Exchange no endpoint diário global, usa o sufixo `.LON` e permite as 100 observações mais recentes com chave gratuita. A franquia gratuita atual é de **25 chamadas por dia**, suficiente para uma consulta EOD diária de `BARC`. O fornecedor também declara que licencia dados oficialmente da LSE. [Documentação do `TIME_SERIES_DAILY`](https://www.alphavantage.co/documentation/#daily), [limite gratuito](https://www.alphavantage.co/support/) e [origens/cobertura](https://www.alphavantage.co/stock_api_landing/)
 
-O símbolo esperado é `BARC.LON`: a LSE confirma o ticker `BARC`, MIC `XLON`, moeda de cotação `GBX` e ISIN `GB0031348658`; o Alpha Vantage documenta `.LON` como sua convenção para a LSE. Esse identificador ainda deve ser confirmado pelo `SYMBOL_SEARCH` com uma chave gratuita real, porque a chave pública `demo` atualmente não aceita consultas arbitrárias. [Instrumento oficial na LSE](https://www.londonstockexchange.com/stock/BARC/barclays-plc/company-page) e [busca de símbolos do Alpha Vantage](https://www.alphavantage.co/documentation/#symbolsearch)
+O símbolo `BARC.LON` foi confirmado diretamente no `TIME_SERIES_DAILY`: o Alpha Vantage retornou 18/08/2026 como último pregão concluído e fechamento de `503,60 GBX`, idêntico ao Yahoo para a mesma data. A LSE confirma o ticker `BARC`, MIC `XLON`, moeda de cotação `GBX` e ISIN `GB0031348658`. [Instrumento oficial na LSE](https://www.londonstockexchange.com/stock/BARC/barclays-plc/company-page)
 
 Não foi encontrado outro provedor que possa ser afirmado, sem credenciais, como fonte gratuita e atual de `BARC/XLON`. O **London Strategic Edge** é uma segunda tentativa experimental: declara API REST gratuita, sem cartão, candles diários e ações internacionais, mas não expõe publicamente a lista que permitiria confirmar BARC nem a linhagem do feed. [API gratuita](https://londonstrategicedge.com/free-market-data-api/) e [limites do databank](https://www.londonstrategicedge.com/data/)
 
 Recomendação operacional:
 
-1. Criar primeiro uma chave gratuita do Alpha Vantage e executar o preflight abaixo.
-2. Se `BARC.LON` devolver o último pregão com preço compatível com a LSE, usar Alpha Vantage para `BARC`, mantendo o Yahoo apenas como último fallback temporário.
-3. Se o Alpha Vantage não confirmar o instrumento ou devolver dado atrasado, testar a busca de BARC no London Strategic Edge antes de desenvolver outro adaptador.
+1. Usar Alpha Vantage para `BARC`, mantendo o Yahoo como fallback.
+2. Preservar o multiplicador `0,01` para converter a cotação em `GBX` para `GBP`.
+3. Tratar limite de requisições ou resposta sem série diária como falha e continuar automaticamente para o Yahoo.
 4. Manter Marketstack somente como fallback para ativos dos EUA que passem no preflight, não para `BARC`.
 
 ## Comparação
 
 | Provedor | Plano grátis | Cobertura relevante | Símbolo provável | Veredito para `BARC` |
 |---|---:|---|---|---|
-| **Alpha Vantage** | 25 chamadas/dia | `TIME_SERIES_DAILY` global; LSE documentada; 100 pontos no `compact` disponível para chaves grátis | `BARC.LON` | **Melhor candidato**, pendente de um único preflight com chave própria |
+| **Alpha Vantage** | 25 chamadas/dia | `TIME_SERIES_DAILY` global; LSE documentada; 100 pontos no `compact` disponível para chaves grátis | `BARC.LON` | **Validado** contra o Yahoo em três pregões consecutivos |
 | **London Strategic Edge** | API grátis; 10 downloads/hora no databank | Declara 3.987 ações US e internacionais e candles de `1d` | não confirmado | Candidato experimental; BARC e origem do feed precisam de preflight |
 | **EODHD** | 20 chamadas/dia | As páginas oficiais divergem: a documentação EOD menciona qualquer ticker, mas a oferta grátis geral limita preços/fundamentos aos EUA | `BARC.LSE` no plano global | Não considerar BARC grátis sem confirmação escrita do fornecedor |
 | **Marketstack** | 100 chamadas/mês; EOD; 1 ano | Declara EOD global, mas o teste do projeto para `BARC.XLON` devolveu como última observação `2023-10-18` | `BARC.XLON` | **Não usar para BARC**; o plano pago Basic não promete corrigir esse feed |
@@ -43,18 +43,18 @@ Fontes: [documentação diária](https://www.alphavantage.co/documentation/#dail
 
 Há uma restrição importante de licença: os termos concedem uso pessoal e não comercial por padrão. Uso por empresa, exibição para terceiros ou outra atividade comercial exige acordo por escrito com o Alpha Vantage. Para o Cost Tracker pessoal isso pode ser aceitável; para disponibilizar o produto a clientes, é necessário tratar a licença separadamente. [Termos oficiais](https://www.alphavantage.co/terms_of_service/)
 
-Preflight sugerido, depois de criar a chave:
+Preflight executado com uma chave própria:
 
 ```text
 GET https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=Barclays&apikey=<KEY>
 GET https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=BARC.LON&outputsize=compact&apikey=<KEY>
 ```
 
-Critérios para aprovar:
+Resultados:
 
-- a busca deve identificar Barclays PLC, Reino Unido/London Stock Exchange;
-- a série deve conter o último pregão esperado, não apenas um registro antigo;
-- o preço deve ser compatível com a cotação oficial em `GBX`;
+- `BARC.LON` retornou 14, 17 e 18/08/2026;
+- os fechamentos coincidiram com o Yahoo nas três datas;
+- o último fechamento concluído foi `503,60 GBX` em 18/08/2026;
 - o mapping deve preservar `BARC`, MIC `XLON`, moeda nativa `GBP` e multiplicador `0,01`, pois 500 GBX equivalem a GBP 5,00.
 
 ### London Strategic Edge
@@ -71,7 +71,7 @@ O EODHD usa a convenção `CODE.EXCHANGE`; sua documentação mostra que a Londo
 GET https://eodhd.com/api/eod/BARC.LSE?api_token=<KEY>&fmt=json&from=<YYYY-MM-DD>
 ```
 
-A documentação EOD diz que o plano gratuito dá acesso a qualquer ticker no último ano, com 20 chamadas/dia, mas a página geral da oferta descreve o plano gratuito como limitado a EOD/fundamentos dos EUA. Como as próprias fontes oficiais divergem e a chave `demo` não aceita BARC, não há evidência suficiente para indicar EODHD como alternativa gratuita para a LSE. O símbolo `BARC.LSE` continua válido para um eventual preflight ou plano global pago. [API EOD](https://eodhd.com/financial-apis/api-for-historical-data-and-volumes), [preços](https://eodhd.com/pricing) e [lista de bolsas](https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours)
+A documentação EOD diz que o plano gratuito dá acesso a qualquer ticker no último ano, com 20 chamadas/dia, mas a página geral da oferta descreve o plano gratuito como limitado a EOD/fundamentos dos EUA. Duas tentativas com chaves próprias devolveram `401 Unauthenticated` antes da validação do símbolo. Portanto, o EODHD permanece fora da integração até a autenticação ser comprovada. O símbolo `BARC.LSE` continua válido para um eventual preflight ou plano global pago. [API EOD](https://eodhd.com/financial-apis/api-for-historical-data-and-volumes), [preços](https://eodhd.com/pricing) e [lista de bolsas](https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours)
 
 ### Marketstack e Twelve Data
 
@@ -89,6 +89,6 @@ O Twelve Data identifica oficialmente Barclays como `BARC`, LSE, MIC `XLON`, cot
 - **Google Finance:** é uma função de planilha, não uma API REST adequada ao backend; a própria ajuda limita acesso histórico pela API do Sheets/Apps Script e alerta que a função não suporta a maioria das bolsas internacionais. [Ajuda oficial](https://support.google.com/docs/answer/3093281)
 - **Stooq:** há downloads CSV públicos, mas não foi encontrada documentação oficial de API, franquia, estabilidade ou licença adequada para automação. Não é prudente substituir um endpoint não contratado do Yahoo por outro endpoint não documentado.
 
-## Decisão antes de implementar
+## Decisão implementada
 
-Não alterar ainda a ordem dos provedores com base apenas na cobertura declarada. A próxima ação segura é criar uma chave Alpha Vantage, executar duas chamadas e guardar o payload do preflight. Se a data de `BARC.LON` for atual e o preço em GBX bater aproximadamente com a [página oficial da LSE](https://www.londonstockexchange.com/stock/BARC/barclays-plc/company-page), há evidência suficiente para projetar o adaptador e o mapping específico do provedor.
+Para instrumentos de Londres com mapping explícito e unidade segura, a ordem passa a ser **Alpha Vantage → Yahoo**. Twelve Data e Marketstack continuam ignorados para `XLON/LSE`; para os ativos americanos, permanece **Twelve Data → Marketstack → Yahoo**.

--- a/docs/research/free-barc-market-data-providers.md
+++ b/docs/research/free-barc-market-data-providers.md
@@ -4,17 +4,17 @@ Pesquisa verificada em **19 de agosto de 2026**, usando fontes oficiais dos prov
 
 ## Conclusão
 
-A alternativa gratuita validada para `BARC` é o **Alpha Vantage**. A documentação oficial inclui ações da London Stock Exchange no endpoint diário global, usa o sufixo `.LON` e permite as 100 observações mais recentes com chave gratuita. A franquia gratuita atual é de **25 chamadas por dia**, suficiente para uma consulta EOD diária de `BARC`. O fornecedor também declara que licencia dados oficialmente da LSE. [Documentação do `TIME_SERIES_DAILY`](https://www.alphavantage.co/documentation/#daily), [limite gratuito](https://www.alphavantage.co/support/) e [origens/cobertura](https://www.alphavantage.co/stock_api_landing/)
+As alternativas gratuitas validadas para `BARC` são **Alpha Vantage** e **EODHD**. O Alpha Vantage inclui ações da London Stock Exchange no endpoint diário global, usa o sufixo `.LON` e permite as 100 observações mais recentes com chave gratuita. A franquia gratuita atual é de **25 chamadas por dia**. O EODHD usa o símbolo `BARC.LSE`, aceitou a chave gratuita no endpoint EOD e anuncia **20 chamadas por dia**. [Documentação do `TIME_SERIES_DAILY`](https://www.alphavantage.co/documentation/#daily), [limite gratuito Alpha Vantage](https://www.alphavantage.co/support/) e [API EODHD](https://eodhd.com/financial-apis/api-for-historical-data-and-volumes)
 
-O símbolo `BARC.LON` foi confirmado diretamente no `TIME_SERIES_DAILY`: o Alpha Vantage retornou 18/08/2026 como último pregão concluído e fechamento de `503,60 GBX`, idêntico ao Yahoo para a mesma data. A LSE confirma o ticker `BARC`, MIC `XLON`, moeda de cotação `GBX` e ISIN `GB0031348658`. [Instrumento oficial na LSE](https://www.londonstockexchange.com/stock/BARC/barclays-plc/company-page)
+Os símbolos `BARC.LON` e `BARC.LSE` foram confirmados diretamente: Alpha Vantage e EODHD retornaram 18/08/2026 como último pregão concluído e fechamento de `503,60 GBX`; o Yahoo também mostrou esse fechamento para a mesma data e já exibiu `496,10 GBX` para 19/08. A LSE confirma o ticker `BARC`, MIC `XLON`, moeda de cotação `GBX` e ISIN `GB0031348658`. [Instrumento oficial na LSE](https://www.londonstockexchange.com/stock/BARC/barclays-plc/company-page)
 
 Não foi encontrado outro provedor que possa ser afirmado, sem credenciais, como fonte gratuita e atual de `BARC/XLON`. O **London Strategic Edge** é uma segunda tentativa experimental: declara API REST gratuita, sem cartão, candles diários e ações internacionais, mas não expõe publicamente a lista que permitiria confirmar BARC nem a linhagem do feed. [API gratuita](https://londonstrategicedge.com/free-market-data-api/) e [limites do databank](https://www.londonstrategicedge.com/data/)
 
 Recomendação operacional:
 
-1. Usar Alpha Vantage para `BARC`, mantendo o Yahoo como fallback.
+1. Usar Alpha Vantage para `BARC`, EODHD como segundo provedor e Yahoo como fallback final.
 2. Preservar o multiplicador `0,01` para converter a cotação em `GBX` para `GBP`.
-3. Tratar limite de requisições ou resposta sem série diária como falha e continuar automaticamente para o Yahoo.
+3. Tratar limite de requisições ou resposta inválida como falha e continuar automaticamente para o próximo provedor.
 4. Manter Marketstack somente como fallback para ativos dos EUA que passem no preflight, não para `BARC`.
 
 ## Comparação
@@ -23,7 +23,7 @@ Recomendação operacional:
 |---|---:|---|---|---|
 | **Alpha Vantage** | 25 chamadas/dia | `TIME_SERIES_DAILY` global; LSE documentada; 100 pontos no `compact` disponível para chaves grátis | `BARC.LON` | **Validado** contra o Yahoo em três pregões consecutivos |
 | **London Strategic Edge** | API grátis; 10 downloads/hora no databank | Declara 3.987 ações US e internacionais e candles de `1d` | não confirmado | Candidato experimental; BARC e origem do feed precisam de preflight |
-| **EODHD** | 20 chamadas/dia | As páginas oficiais divergem: a documentação EOD menciona qualquer ticker, mas a oferta grátis geral limita preços/fundamentos aos EUA | `BARC.LSE` no plano global | Não considerar BARC grátis sem confirmação escrita do fornecedor |
+| **EODHD** | 20 chamadas/dia | O endpoint EOD gratuito aceitou `BARC.LSE`; a documentação permite o último ano | `BARC.LSE` | **Validado** com o mesmo fechamento do Alpha Vantage |
 | **Marketstack** | 100 chamadas/mês; EOD; 1 ano | Declara EOD global, mas o teste do projeto para `BARC.XLON` devolveu como última observação `2023-10-18` | `BARC.XLON` | **Não usar para BARC**; o plano pago Basic não promete corrigir esse feed |
 | **Twelve Data** | 8 créditos/minuto e 800/dia | Grátis para ações/ETFs dos EUA; internacional apenas em símbolos de teste | `BARC`, exchange `LSE`, MIC `XLON` | Catálogo e preço atuais existem, mas o EOD global requer Grow ou superior |
 | **FMP** | 250 chamadas/dia | O Basic grátis oferece EOD apenas para um conjunto limitado; cobertura UK aparece no Premium | normalmente ticker com extensão de bolsa | Não é uma alternativa gratuita para BARC |
@@ -71,7 +71,7 @@ O EODHD usa a convenção `CODE.EXCHANGE`; sua documentação mostra que a Londo
 GET https://eodhd.com/api/eod/BARC.LSE?api_token=<KEY>&fmt=json&from=<YYYY-MM-DD>
 ```
 
-A documentação EOD diz que o plano gratuito dá acesso a qualquer ticker no último ano, com 20 chamadas/dia, mas a página geral da oferta descreve o plano gratuito como limitado a EOD/fundamentos dos EUA. Duas tentativas com chaves próprias devolveram `401 Unauthenticated` antes da validação do símbolo. Portanto, o EODHD permanece fora da integração até a autenticação ser comprovada. O símbolo `BARC.LSE` continua válido para um eventual preflight ou plano global pago. [API EOD](https://eodhd.com/financial-apis/api-for-historical-data-and-volumes), [preços](https://eodhd.com/pricing) e [lista de bolsas](https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours)
+A documentação EOD diz que o plano gratuito dá acesso a qualquer ticker no último ano, com 20 chamadas/dia, embora a página geral da oferta descreva o plano gratuito como limitado a EOD/fundamentos dos EUA. O preflight autenticado resolveu a ambiguidade para este caso: `AAPL.US` e `BARC.LSE` responderam `HTTP 200`, e `BARC.LSE` retornou fechamento de `503,60 GBX` em 18/08/2026, igual ao Alpha Vantage. O token deve ser enviado como valor do query parameter `api_token`; a variável `EODHD_API_KEY` deve conter somente o token. [API EOD](https://eodhd.com/financial-apis/api-for-historical-data-and-volumes), [preços](https://eodhd.com/pricing) e [lista de bolsas](https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours)
 
 ### Marketstack e Twelve Data
 
@@ -91,4 +91,4 @@ O Twelve Data identifica oficialmente Barclays como `BARC`, LSE, MIC `XLON`, cot
 
 ## Decisão implementada
 
-Para instrumentos de Londres com mapping explícito e unidade segura, a ordem passa a ser **Alpha Vantage → Yahoo**. Twelve Data e Marketstack continuam ignorados para `XLON/LSE`; para os ativos americanos, permanece **Twelve Data → Marketstack → Yahoo**.
+Para instrumentos de Londres com mapping explícito e unidade segura, a ordem passa a ser **Alpha Vantage → EODHD → Yahoo**. Twelve Data e Marketstack continuam ignorados para `XLON/LSE`; para os ativos americanos, permanece **Twelve Data → Marketstack → Yahoo**.


### PR DESCRIPTION
## Summary
- add Alpha Vantage as the primary LSE quote provider
- add EODHD as the second LSE provider, using `api_token` from `EODHD_API_KEY`
- route London instruments through Alpha Vantage → EODHD → Yahoo
- preserve the US route Twelve Data → Marketstack → Yahoo
- require explicit LSE mappings and a `0.01` multiplier to convert GBX to GBP

## Validation
- 81/81 automated tests pass
- direct preflight: Alpha Vantage `BARC.LON` and EODHD `BARC.LSE` both returned 503.6 GBX for 2026-08-18
- Yahoo returned 496.1 GBX for 2026-08-19