### PR TITLE
Simplify investment portfolio overview

### DIFF
--- a/frontend/src/features/investments/components/PortfolioList.test.tsx
+++ b/frontend/src/features/investments/components/PortfolioList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { InstrumentPositionDto } from '../types';
+import { PortfolioList } from './PortfolioList';
+
+const position: InstrumentPositionDto = {
+  instrumentId: 'barc-id',
+  name: 'Barclays',
+  ticker: 'BARC',
+  mic: 'XLON',
+  assetClass: 'STOCKS',
+  kind: 'STOCK',
+  valuationMode: 'MARKET_QUOTE',
+  nativeCurrency: 'GBP',
+  allocationScore: 10,
+  quantity: 100,
+  nativeValue: 503.6,
+  valueEur: 580,
+  portfolioWeight: 0.25,
+  freshness: 'FRESH',
+  marketData: {
+    asOf: '2026-08-18',
+    source: 'ALPHA_VANTAGE',
+    freshness: 'FRESH',
+    price: 5.036,
+    currency: 'GBP',
+    priceKind: 'EOD_CLOSE',
+    providerSymbol: 'BARC.LON'
+  }
+};
+
+describe('PortfolioList', () => {
+  it('keeps calculation and source details out of the portfolio overview', () => {
+    render(
+      <MemoryRouter>
+        <PortfolioList positions={[position]} selectedClass="ALL" onSelectClass={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Ver cálculo e fontes')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Detalhes' })).toHaveAttribute('href', '/investimentos/ativos/barc-id');
+    expect(screen.getByRole('link', { name: 'Ver detalhes' })).toHaveAttribute('href', '/investimentos/ativos/barc-id');
+  });
+});

--- a/frontend/src/features/investments/components/PortfolioList.tsx
+++ b/frontend/src/features/investments/components/PortfolioList.tsx
@@ -5,7 +5,6 @@ import { formatDateIsoToPt, formatPercent } from '../../../utils/format';
 import { PrivacyMask } from '../../../contexts/PrivacyContext';
 import { FreshnessBadge } from './FreshnessBadge';
 import { InvestmentMoney } from './InvestmentMoney';
-import { ValuationBreakdown } from './ValuationBreakdown';
 
 interface PortfolioListProps {
   positions: InstrumentPositionDto[];
@@ -103,10 +102,6 @@ export function PortfolioList({ positions, selectedClass, onSelectClass }: Portf
                     <td>
                       <FreshnessBadge status={positionFreshness(position)} />
                       {oldestPositionDate(position) && <small className="as-of">{formatDateIsoToPt(oldestPositionDate(position) ?? '')}</small>}
-                      <details className="valuation-source-details">
-                        <summary>Ver cálculo e fontes</summary>
-                        <ValuationBreakdown position={position} compact />
-                      </details>
                     </td>
                     <td><Link className="table-action-link" to={`/investimentos/ativos/${position.instrumentId}`}>Detalhes</Link></td>
                   </tr>
@@ -128,10 +123,6 @@ export function PortfolioList({ positions, selectedClass, onSelectClass }: Portf
                   <div><dt>Peso</dt><dd>{position.portfolioWeight == null ? '—' : formatPercent(position.portfolioWeight)}</dd></div>
                   <div><dt>Dados</dt><dd><FreshnessBadge status={positionFreshness(position)} /></dd></div>
                 </dl>
-                <details className="valuation-source-details">
-                  <summary>Ver cálculo e fontes</summary>
-                  <ValuationBreakdown position={position} compact />
-                </details>
                 <Link className="investment-secondary-link" to={`/investimentos/ativos/${position.instrumentId}`}>Ver detalhes</Link>
               </article>
             ))}

--- a/frontend/src/features/investments/components/ValuationBreakdown.tsx
+++ b/frontend/src/features/investments/components/ValuationBreakdown.tsx
@@ -7,6 +7,8 @@ function sourceLabel(source?: string | null) {
   switch (source) {
     case 'TWELVE_DATA': return 'Twelve Data';
     case 'MARKETSTACK': return 'Marketstack';
+    case 'ALPHA_VANTAGE': return 'Alpha Vantage';
+    case 'EODHD': return 'EODHD';
     case 'YAHOO_TEST': return 'Yahoo (fallback)';
     case 'ECB': return 'Banco Central Europeu (ECB)';
     case 'BCB_PTAX': return 'Banco Central do Brasil (PTAX)';
@@ -20,7 +22,7 @@ function referenceDate(value?: string | null) {
   return value ? formatDateIsoToPt(value) : 'data indisponível';
 }
 
-export function ValuationBreakdown({ position, compact = false }: { position: InstrumentPositionDto; compact?: boolean }) {
+export function ValuationBreakdown({ position }: { position: InstrumentPositionDto }) {
   const quote = position.marketData;
   const fx = position.fxData;
   const quantity = position.quantity;
@@ -33,7 +35,7 @@ export function ValuationBreakdown({ position, compact = false }: { position: In
     : null;
 
   return (
-    <dl className={compact ? 'valuation-breakdown valuation-breakdown-compact' : 'valuation-breakdown'}>
+    <dl className="valuation-breakdown">
       {position.valuationMode === 'MARKET_QUOTE' && (
         <div>
           <dt>Cotação utilizada</dt>

--- a/frontend/src/features/investments/investments.css
+++ b/frontend/src/features/investments/investments.css
@@ -539,17 +539,6 @@
   margin-top: 0.2rem;
 }
 
-.valuation-source-details {
-  margin-top: 0.4rem;
-}
-
-.valuation-source-details summary {
-  color: var(--brand);
-  cursor: pointer;
-  font-size: 0.68rem;
-  font-weight: 650;
-}
-
 .valuation-breakdown {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
@@ -581,15 +570,6 @@
 .valuation-breakdown dd small {
   color: var(--text-secondary);
   font-size: 0.65rem;
-}
-
-.valuation-breakdown-compact {
-  grid-template-columns: minmax(250px, 1fr);
-  margin-top: 0.5rem;
-}
-
-.valuation-breakdown-compact > div {
-  padding: 0.5rem;
 }
 
 .fx-rate-list {


### PR DESCRIPTION
## Summary
- remove “Ver cálculo e fontes” from the desktop portfolio table
- remove the same expandable section from mobile investment cards
- keep the full valuation breakdown on the instrument details page
- add friendly labels for Alpha Vantage and EODHD in details

## Validation
- 37/37 frontend tests pass
- production frontend build succeeds